### PR TITLE
Bump version to 0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -101,7 +101,7 @@ dependencies = [
 
 [[package]]
 name = "atm"
-version = "0.1.7"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "atm-core",
@@ -129,7 +129,7 @@ dependencies = [
 
 [[package]]
 name = "atm-core"
-version = "0.1.7"
+version = "0.2.0"
 dependencies = [
  "chrono",
  "procfs",
@@ -143,7 +143,7 @@ dependencies = [
 
 [[package]]
 name = "atm-protocol"
-version = "0.1.7"
+version = "0.2.0"
 dependencies = [
  "atm-core",
  "chrono",
@@ -154,7 +154,7 @@ dependencies = [
 
 [[package]]
 name = "atm-tmux"
-version = "0.1.7"
+version = "0.2.0"
 dependencies = [
  "async-trait",
  "dirs",
@@ -167,7 +167,7 @@ dependencies = [
 
 [[package]]
 name = "atm-tui"
-version = "0.1.7"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "atm-core",
@@ -189,7 +189,7 @@ dependencies = [
 
 [[package]]
 name = "atmd"
-version = "0.1.7"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "atm-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ bin-dir = "atm-{ version }/{ bin }{ binary-ext }"
 pkg-fmt = "tgz"
 
 [workspace.package]
-version = "0.1.7"
+version = "0.2.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/damelLP/agent-tmux-manager"
@@ -76,11 +76,11 @@ clap = { version = "4.4", features = ["derive"] }
 tempfile = "3.14"
 
 # Internal crates (version required for crates.io, path for local dev)
-atm-core = { version = "0.1.1", path = "crates/atm-core" }
-atm-protocol = { version = "0.1.1", path = "crates/atm-protocol" }
-atm-tmux = { version = "0.1.1", path = "crates/atm-tmux" }
-atm-tui = { version = "0.1.1", path = "crates/atm" }
-atmd = { version = "0.1.1", path = "crates/atmd" }
+atm-core = { version = "0.2.0", path = "crates/atm-core" }
+atm-protocol = { version = "0.2.0", path = "crates/atm-protocol" }
+atm-tmux = { version = "0.2.0", path = "crates/atm-tmux" }
+atm-tui = { version = "0.2.0", path = "crates/atm" }
+atmd = { version = "0.2.0", path = "crates/atmd" }
 
 [dependencies]
 # Required for root package to compile the binaries


### PR DESCRIPTION
## Summary
- Bump workspace version from 0.1.7 to 0.2.0
- Bump internal crate dependency versions from 0.1.1 to 0.2.0
- Regenerated Cargo.lock

## Test plan
- [x] `cargo build --release` succeeds
- [x] `atm --version` reports `0.2.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)