### PR TITLE
feat: add harness registry for spawn and discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@
 [![Build Status](https://github.com/damelLP/agent-tmux-manager/actions/workflows/release.yml/badge.svg)](https://github.com/damelLP/agent-tmux-manager/actions)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 
-Real-time management for Claude Code agents across tmux sessions.
+Real-time management for coding agents across tmux sessions.
 
 ## What it does
 
-ATM gives you a live dashboard and CLI for every Claude Code agent running in tmux. See context usage, cost, model, and activity at a glance — and control agents without switching panes.
+ATM gives you a live dashboard and CLI for coding agents running in tmux, including Claude Code and pi. See context usage, cost, model, and activity at a glance — and control agents without switching panes.
 
 - **Dashboard** — real-time TUI with session tree, context bars, cost tracking, and live terminal capture
 - **Agent control** — spawn, kill, interrupt, send text, and reply to prompts from the CLI
@@ -33,12 +33,30 @@ cargo install atm && atm setup
 atm                    # launch TUI (starts daemon automatically)
 ```
 
-Sessions appear as you use Claude Code. Press `Enter` to jump to any session, `q` to quit.
+Sessions appear as you use supported coding-agent harnesses. Press `Enter` to jump to any session, `q` to quit.
 
 ## CLI at a glance
 
 ```bash
-atm spawn -m opus -d right         # spawn agent with model and direction
+atm spawn -m opus -d right         # spawn default harness with model and direction
+atm spawn --harness pi             # spawn a specific harness
+ATM_SPAWN_PI_BIN=mise ATM_SPAWN_PI_ARGS='x pi' atm spawn --harness pi
+```
+
+ATM auto-creates `~/.config/atm/config.toml` with defaults when spawn config is first loaded. Default spawn harness and per-harness spawn defaults can be configured there:
+
+```toml
+[harness]
+default = "pi"
+
+[harness.pi]
+binary = "mise"
+default_args = ["x", "pi"]
+```
+
+Environment overrides still take precedence when set (`ATM_SPAWN_PI_BIN/ARGS`, then legacy `ATM_SPAWN_BIN/ARGS`); otherwise config values are used, then built-in defaults.
+
+```
 atm kill <id>                      # kill agent and close pane
 atm interrupt <id>                 # Ctrl+C an agent
 atm send <id> "fix the tests"     # send text to agent
@@ -55,10 +73,10 @@ atm layout pair                    # two agents + ATM sidebar
 ## How it works
 
 ```
-Claude Code  ──hook──▶  atmd (daemon)  ◀──socket──  atm (TUI/CLI)
+Claude Code / pi  ──hook/extension──▶  atmd (daemon)  ◀──socket──  atm (TUI/CLI)
 ```
 
-`atm setup` registers hooks in `~/.claude/settings.json`. Claude Code fires events on every tool use, status update, and lifecycle change. The `atm-hook` script forwards these to the `atmd` daemon over a Unix socket, and `atm` connects for real-time display.
+`atm setup` registers supported harness integrations (Claude Code hooks and the pi extension). Harness events are forwarded to the `atmd` daemon over a Unix socket, and `atm` connects for real-time display.
 
 ## Documentation
 

--- a/crates/atm-core/src/harness.rs
+++ b/crates/atm-core/src/harness.rs
@@ -20,15 +20,25 @@ use std::fmt;
 
 /// Which coding-agent harness is driving this session.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, Default)]
+#[non_exhaustive]
 #[serde(rename_all = "snake_case")]
 pub enum Harness {
     /// Claude Code (Anthropic).
     ClaudeCode,
     /// pi (<https://pi.dev/>) — provider-agnostic harness.
     Pi,
+    /// OpenAI Codex CLI.
+    Codex,
+    /// Amp coding agent.
+    Amp,
+    /// Qwen Code CLI.
+    Qwen,
+    /// Gemini CLI.
+    Gemini,
     /// Unknown harness — discovered via process scanning before any
     /// adapter event arrived, or a future harness we haven't tagged.
     #[default]
+    #[serde(other)]
     Unknown,
 }
 
@@ -39,6 +49,10 @@ impl Harness {
         match self {
             Self::ClaudeCode => "claude",
             Self::Pi => "pi",
+            Self::Codex => "codex",
+            Self::Amp => "amp",
+            Self::Qwen => "qwen",
+            Self::Gemini => "gemini",
             Self::Unknown => "?",
         }
     }
@@ -49,6 +63,10 @@ impl fmt::Display for Harness {
         f.write_str(match self {
             Self::ClaudeCode => "Claude Code",
             Self::Pi => "pi",
+            Self::Codex => "Codex CLI",
+            Self::Amp => "Amp",
+            Self::Qwen => "Qwen Code",
+            Self::Gemini => "Gemini CLI",
             Self::Unknown => "unknown",
         })
     }
@@ -65,6 +83,13 @@ mod tests {
             "\"claude_code\""
         );
         assert_eq!(serde_json::to_string(&Harness::Pi).unwrap(), "\"pi\"");
+        assert_eq!(serde_json::to_string(&Harness::Codex).unwrap(), "\"codex\"");
+        assert_eq!(serde_json::to_string(&Harness::Amp).unwrap(), "\"amp\"");
+        assert_eq!(serde_json::to_string(&Harness::Qwen).unwrap(), "\"qwen\"");
+        assert_eq!(
+            serde_json::to_string(&Harness::Gemini).unwrap(),
+            "\"gemini\""
+        );
         assert_eq!(
             serde_json::to_string(&Harness::Unknown).unwrap(),
             "\"unknown\""
@@ -80,6 +105,10 @@ mod tests {
     fn short_tag_matches_display_intent() {
         assert_eq!(Harness::ClaudeCode.short_tag(), "claude");
         assert_eq!(Harness::Pi.short_tag(), "pi");
+        assert_eq!(Harness::Codex.short_tag(), "codex");
+        assert_eq!(Harness::Amp.short_tag(), "amp");
+        assert_eq!(Harness::Qwen.short_tag(), "qwen");
+        assert_eq!(Harness::Gemini.short_tag(), "gemini");
         assert_eq!(Harness::Unknown.short_tag(), "?");
     }
 }

--- a/crates/atm-core/src/harness_registry.rs
+++ b/crates/atm-core/src/harness_registry.rs
@@ -1,0 +1,294 @@
+//! Built-in coding-agent harness registry.
+//!
+//! The registry is intentionally data-first: spawning, process discovery,
+//! and future config overlays can all consume the same definitions instead
+//! of special-casing every CLI agent in each subsystem.
+
+use crate::Harness;
+
+/// How ATM should supply an initial prompt to a harness.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PromptMode {
+    /// The harness accepts a prompt via a command-line flag.
+    Flag(&'static str),
+    /// The harness must be launched first, then text is injected with tmux
+    /// `send-keys`.
+    KeystrokeInjection,
+    /// ATM does not know how to pass an initial prompt for this harness yet.
+    Unsupported,
+}
+
+/// A declarative process-path matcher used by daemon discovery.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProcessMatcher {
+    /// Path or argv exactly equals this string.
+    Exact(&'static str),
+    /// Path or argv ends with this suffix.
+    Suffix(&'static str),
+    /// Path or argv contains this substring.
+    Contains(&'static str),
+}
+
+impl ProcessMatcher {
+    /// Returns true if `candidate` satisfies this matcher.
+    #[must_use]
+    pub fn matches(&self, candidate: &str) -> bool {
+        match self {
+            Self::Exact(expected) => candidate == *expected,
+            Self::Suffix(suffix) => candidate.ends_with(suffix),
+            Self::Contains(needle) => candidate.contains(needle),
+        }
+    }
+}
+
+/// Metadata for a CLI coding-agent harness.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct HarnessDefinition {
+    /// Stable CLI/config identifier (e.g. `claude`, `pi`, `codex`).
+    pub id: &'static str,
+    /// Alternate CLI/config identifiers accepted by lookup.
+    pub aliases: &'static [&'static str],
+    /// Human-readable display name.
+    pub display_name: &'static str,
+    /// Session harness tag used in ATM's domain model.
+    pub harness: Harness,
+    /// Binary to launch for `atm spawn`.
+    pub binary: &'static str,
+    /// Default arguments inserted immediately after the binary.
+    pub default_args: &'static [&'static str],
+    /// Flag used to set the model, when supported.
+    pub model_flag: Option<&'static str>,
+    /// How to pass an initial prompt, when/if spawn grows that option.
+    pub prompt_mode: PromptMode,
+    /// Arguments used for installation/version probing.
+    pub version_args: &'static [&'static str],
+    /// Process path/argv matchers used by discovery.
+    pub process_matchers: &'static [ProcessMatcher],
+    /// Whether this harness should be detected by daemon `/proc` discovery.
+    ///
+    /// Keep this false until a harness has an adapter/status source, otherwise
+    /// ATM may show unmanaged pending sessions with misleading badges.
+    pub discovery_enabled: bool,
+    /// Whether bare argv0 matches are allowed during cmdline scanning.
+    ///
+    /// This is safe for distinctive command names like `claude`, but unsafe for
+    /// short ambiguous names like `pi` (a random program can take `pi` as data).
+    /// Bare matches are never accepted from arbitrary positional arguments.
+    pub allow_bare_cmdline_match: bool,
+}
+
+const CLAUDE_MATCHERS: &[ProcessMatcher] = &[
+    ProcessMatcher::Exact("claude"),
+    ProcessMatcher::Suffix("/claude"),
+    ProcessMatcher::Contains("claude/versions/"),
+];
+
+const PI_MATCHERS: &[ProcessMatcher] = &[
+    ProcessMatcher::Suffix("/bin/pi"),
+    ProcessMatcher::Suffix("/pi"),
+    ProcessMatcher::Contains("pi-coding-agent"),
+];
+
+const CODEX_MATCHERS: &[ProcessMatcher] = &[
+    ProcessMatcher::Exact("codex"),
+    ProcessMatcher::Suffix("/codex"),
+    ProcessMatcher::Contains("codex-cli"),
+];
+
+const AMP_MATCHERS: &[ProcessMatcher] =
+    &[ProcessMatcher::Exact("amp"), ProcessMatcher::Suffix("/amp")];
+
+const QWEN_MATCHERS: &[ProcessMatcher] = &[
+    ProcessMatcher::Exact("qwen"),
+    ProcessMatcher::Suffix("/qwen"),
+    ProcessMatcher::Exact("qwen-code"),
+    ProcessMatcher::Suffix("/qwen-code"),
+];
+
+const GEMINI_MATCHERS: &[ProcessMatcher] = &[
+    ProcessMatcher::Exact("gemini"),
+    ProcessMatcher::Suffix("/gemini"),
+    ProcessMatcher::Contains("gemini-cli"),
+];
+
+/// Built-in harness definitions.
+pub const BUILTIN_HARNESSES: &[HarnessDefinition] = &[
+    HarnessDefinition {
+        id: "claude",
+        aliases: &["claude_code", "claude-code", "cc"],
+        display_name: "Claude Code",
+        harness: Harness::ClaudeCode,
+        binary: "claude",
+        default_args: &[],
+        model_flag: Some("--model"),
+        prompt_mode: PromptMode::KeystrokeInjection,
+        version_args: &["--version"],
+        process_matchers: CLAUDE_MATCHERS,
+        discovery_enabled: true,
+        allow_bare_cmdline_match: true,
+    },
+    HarnessDefinition {
+        id: "pi",
+        aliases: &[],
+        display_name: "pi",
+        harness: Harness::Pi,
+        binary: "pi",
+        default_args: &[],
+        model_flag: Some("--model"),
+        prompt_mode: PromptMode::KeystrokeInjection,
+        version_args: &["--version"],
+        process_matchers: PI_MATCHERS,
+        discovery_enabled: true,
+        allow_bare_cmdline_match: false,
+    },
+    HarnessDefinition {
+        id: "codex",
+        aliases: &["codex-cli"],
+        display_name: "Codex CLI",
+        harness: Harness::Codex,
+        binary: "codex",
+        default_args: &[],
+        model_flag: None,
+        prompt_mode: PromptMode::KeystrokeInjection,
+        version_args: &["--version"],
+        process_matchers: CODEX_MATCHERS,
+        discovery_enabled: false,
+        allow_bare_cmdline_match: true,
+    },
+    HarnessDefinition {
+        id: "amp",
+        aliases: &[],
+        display_name: "Amp",
+        harness: Harness::Amp,
+        binary: "amp",
+        default_args: &[],
+        model_flag: None,
+        prompt_mode: PromptMode::KeystrokeInjection,
+        version_args: &["--version"],
+        process_matchers: AMP_MATCHERS,
+        discovery_enabled: false,
+        allow_bare_cmdline_match: true,
+    },
+    HarnessDefinition {
+        id: "qwen",
+        aliases: &["qwen-code"],
+        display_name: "Qwen Code",
+        harness: Harness::Qwen,
+        binary: "qwen",
+        default_args: &[],
+        model_flag: None,
+        prompt_mode: PromptMode::KeystrokeInjection,
+        version_args: &["--version"],
+        process_matchers: QWEN_MATCHERS,
+        discovery_enabled: false,
+        allow_bare_cmdline_match: true,
+    },
+    HarnessDefinition {
+        id: "gemini",
+        aliases: &["gemini-cli"],
+        display_name: "Gemini CLI",
+        harness: Harness::Gemini,
+        binary: "gemini",
+        default_args: &[],
+        model_flag: None,
+        prompt_mode: PromptMode::KeystrokeInjection,
+        version_args: &["--version"],
+        process_matchers: GEMINI_MATCHERS,
+        discovery_enabled: false,
+        allow_bare_cmdline_match: true,
+    },
+];
+
+/// Returns the default harness definition used by `atm spawn`.
+#[must_use]
+pub fn default_harness_definition() -> &'static HarnessDefinition {
+    // Keep the historic default behavior: `atm spawn` launches Claude Code.
+    if let Some(definition) = find_harness_definition("claude") {
+        definition
+    } else {
+        // BUILTIN_HARNESSES is defined in this module with Claude first; this
+        // defensive fallback avoids panicking if that invariant changes.
+        BUILTIN_HARNESSES
+            .iter()
+            .next()
+            .unwrap_or(&FALLBACK_HARNESS_DEFINITION)
+    }
+}
+
+const FALLBACK_HARNESS_DEFINITION: HarnessDefinition = HarnessDefinition {
+    id: "unknown",
+    aliases: &[],
+    display_name: "unknown",
+    harness: Harness::Unknown,
+    binary: "claude",
+    default_args: &[],
+    model_flag: None,
+    prompt_mode: PromptMode::Unsupported,
+    version_args: &[],
+    process_matchers: &[],
+    discovery_enabled: false,
+    allow_bare_cmdline_match: false,
+};
+
+/// Finds a built-in harness definition by canonical id or alias.
+#[must_use]
+pub fn find_harness_definition(id: &str) -> Option<&'static HarnessDefinition> {
+    BUILTIN_HARNESSES
+        .iter()
+        .find(|definition| definition.id == id || definition.aliases.contains(&id))
+}
+
+/// Iterates over built-in harness definitions in discovery priority order.
+pub fn builtin_harnesses() -> impl Iterator<Item = &'static HarnessDefinition> {
+    BUILTIN_HARNESSES.iter()
+}
+
+/// Returns a comma-separated list of built-in harness ids for diagnostics.
+#[must_use]
+pub fn builtin_harness_ids_display() -> String {
+    BUILTIN_HARNESSES
+        .iter()
+        .map(|definition| definition.id)
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn finds_default_claude_harness() {
+        let definition = default_harness_definition();
+        assert_eq!(definition.id, "claude");
+        assert_eq!(definition.harness, Harness::ClaudeCode);
+    }
+
+    #[test]
+    fn aliases_resolve_to_canonical_harnesses() {
+        assert_eq!(
+            find_harness_definition("claude_code").map(|d| d.id),
+            Some("claude")
+        );
+        assert_eq!(
+            find_harness_definition("qwen-code").map(|d| d.id),
+            Some("qwen")
+        );
+        assert_eq!(find_harness_definition("nope").map(|d| d.id), None);
+    }
+
+    #[test]
+    fn process_matchers_cover_expected_paths() {
+        let claude = find_harness_definition("claude").unwrap_or(default_harness_definition());
+        assert!(claude.process_matchers.iter().any(|m| m.matches("claude")));
+        assert!(claude
+            .process_matchers
+            .iter()
+            .any(|m| m.matches("/usr/local/bin/claude")));
+
+        let pi = find_harness_definition("pi").unwrap_or(default_harness_definition());
+        assert!(pi.process_matchers.iter().any(|m| m.matches("/usr/bin/pi")));
+        assert!(pi.discovery_enabled);
+        assert!(!pi.allow_bare_cmdline_match);
+    }
+}

--- a/crates/atm-core/src/lib.rs
+++ b/crates/atm-core/src/lib.rs
@@ -1,4 +1,4 @@
-//! ATM Core - Shared types for Claude Code management
+//! ATM Core - Shared types for coding-agent management
 //!
 //! This crate provides the core domain types shared between
 //! the daemon (atmd) and TUI (atm).
@@ -12,6 +12,7 @@ pub mod context;
 pub mod cost;
 pub mod error;
 pub mod harness;
+pub mod harness_registry;
 pub mod lifecycle;
 pub mod model;
 pub mod project;
@@ -25,6 +26,10 @@ pub use context::{ContextUsage, TokenCount};
 pub use cost::Money;
 pub use error::{DomainError, DomainResult};
 pub use harness::Harness;
+pub use harness_registry::{
+    builtin_harness_ids_display, builtin_harnesses, default_harness_definition,
+    find_harness_definition, HarnessDefinition, ProcessMatcher, PromptMode,
+};
 pub use lifecycle::{LifecycleEvent, NeedsInputReason, NotificationKind};
 pub use model::{derive_display_name, Model};
 pub use project::{resolve_project_root, resolve_worktree_info};

--- a/crates/atmd/src/discovery.rs
+++ b/crates/atmd/src/discovery.rs
@@ -20,7 +20,7 @@
 
 use std::path::PathBuf;
 
-use atm_core::{Harness, SessionId};
+use atm_core::{builtin_harnesses, Harness, HarnessDefinition, SessionId};
 use thiserror::Error;
 use tracing::{debug, info, trace, warn};
 
@@ -254,9 +254,9 @@ impl DiscoveryService {
 
 /// Scans /proc for coding-agent processes.
 ///
-/// Single pass: for each PID, dispatches through per-harness detectors
-/// (Claude → pi → …). The first detector that matches wins. Adding a
-/// new harness means adding one detector below; no caller changes.
+/// Single pass: for each PID, dispatches through the built-in harness
+/// registry. The first matching definition wins. Adding a new built-in
+/// harness means adding one data record in atm-core; no caller changes.
 ///
 /// This function performs blocking I/O and should be called via
 /// `spawn_blocking`.
@@ -287,111 +287,67 @@ fn scan_agent_processes() -> Result<Vec<DiscoveredProcess>, DiscoveryError> {
 
 /// Tries each registered harness detector against `pid`. Returns the
 /// first match or `None`.
-///
-/// Order matters insofar as we want common, fast checks first. Both
-/// `check_claude_process` and `check_pi_process` walk `/proc/{pid}/exe`
-/// then fall back to cmdline; cost is similar. Claude is checked first
-/// only because it's the historic default.
 fn detect_agent_process(pid: u32) -> Option<DiscoveredProcess> {
-    if let Some(p) = check_claude_process(pid) {
-        return Some(p);
-    }
-    if let Some(p) = check_pi_process(pid) {
-        return Some(p);
-    }
-    None
+    builtin_harnesses()
+        .filter(|definition| definition.discovery_enabled)
+        .find_map(|definition| check_harness_process(pid, definition))
 }
 
-/// Checks if a path string represents a Claude executable.
-///
-/// Matches:
-/// - `/path/to/claude` (ends with /claude)
-/// - `claude` (bare command name)
-/// - `~/.local/share/claude/versions/X.Y.Z/...` (versioned installs)
-fn is_claude_path(path: &str) -> bool {
-    path.ends_with("/claude") || path == "claude" || path.contains("claude/versions/")
-}
-
-/// Checks if a PID is a Claude Code process.
+/// Checks if a PID matches a built-in harness definition.
 ///
 /// First attempts to identify via `/proc/{pid}/exe`. Falls back to
-/// `/proc/{pid}/cmdline` for wrapper scripts.
-fn check_claude_process(pid: u32) -> Option<DiscoveredProcess> {
-    if let Some(process) = check_via_exe(pid, is_claude_path, Harness::ClaudeCode) {
+/// `/proc/{pid}/cmdline` for shebang/node-based CLIs and path-like command
+/// arguments. Bare command-name matches are deliberately limited to argv0 to
+/// avoid false positives from arbitrary positional data.
+fn check_harness_process(
+    pid: u32,
+    definition: &'static HarnessDefinition,
+) -> Option<DiscoveredProcess> {
+    if let Some(process) = check_via_exe(pid, definition) {
         return Some(process);
     }
 
-    let result = check_via_cmdline(pid, is_claude_path, Harness::ClaudeCode);
+    let result = check_via_cmdline(pid, definition);
 
     if result.is_some() {
         trace!(
             pid,
-            "Detected Claude via cmdline fallback (exe check failed)"
+            harness = definition.id,
+            "Detected harness via cmdline fallback (exe check failed)"
         );
     }
 
     result
 }
 
-/// Checks if a PID is a `pi` (https://pi.dev/) process.
-///
-/// `pi` is installed as a node-shebang script — `comm` reports
-/// `node` rather than `pi` across most setups, so cmdline is the
-/// authoritative match. Recipe (`pgrep -fn 'pi-coding-agent|/bin/pi$'`)
-/// is encoded as `is_pi_path`.
-fn check_pi_process(pid: u32) -> Option<DiscoveredProcess> {
-    if let Some(process) = check_via_exe(pid, is_pi_path, Harness::Pi) {
-        return Some(process);
-    }
-    let result = check_via_cmdline(pid, is_pi_path, Harness::Pi);
-    if result.is_some() {
-        trace!(pid, "Detected pi via cmdline fallback (exe check failed)");
-    }
-    result
-}
-
-/// Checks if a path string represents a pi executable.
-///
-/// Matches:
-/// - `/path/to/bin/pi` (canonical install)
-/// - `*/pi` (any path ending with `/pi` — covers non-`bin` install locations)
-/// - `.../pi-coding-agent/...` (npm package path; pi is published as
-///   `@mariozechner/pi-coding-agent`)
-///
-/// Bare `"pi"` is intentionally not matched: `check_via_cmdline`
-/// scans every non-flag argv entry, so a bare-string match would
-/// false-positive on any process that happens to take `pi` as an
-/// argument. Real pi invocations land in argv as either an absolute
-/// path or under the published npm package prefix.
-fn is_pi_path(path: &str) -> bool {
-    path.ends_with("/bin/pi") || path.ends_with("/pi") || path.contains("pi-coding-agent")
-}
-
-/// Generic helper: tests `/proc/{pid}/exe` against `path_matches` and
-/// returns a `DiscoveredProcess` tagged with `harness` on match.
-fn check_via_exe(
-    pid: u32,
-    path_matches: fn(&str) -> bool,
-    harness: Harness,
-) -> Option<DiscoveredProcess> {
+/// Generic helper: tests `/proc/{pid}/exe` against a harness definition and
+/// returns a `DiscoveredProcess` tagged with that harness on match.
+fn check_via_exe(pid: u32, definition: &'static HarnessDefinition) -> Option<DiscoveredProcess> {
     let exe_path = format!("/proc/{pid}/exe");
     let exe = std::fs::read_link(&exe_path).ok()?;
     let exe_str = exe.to_string_lossy();
 
-    if !path_matches(&exe_str) {
+    if !definition
+        .process_matchers
+        .iter()
+        .any(|matcher| matcher.matches(&exe_str))
+    {
         return None;
     }
 
-    get_process_info(pid, harness)
+    get_process_info(pid, definition.harness)
 }
 
-/// Generic helper: scans `/proc/{pid}/cmdline` arguments and returns
-/// a `DiscoveredProcess` tagged with `harness` if any non-flag arg
-/// satisfies `path_matches`.
+/// Generic helper: scans `/proc/{pid}/cmdline` arguments and returns a
+/// `DiscoveredProcess` tagged with the harness if a safe command-shaped arg
+/// satisfies the definition's process matchers.
+///
+/// Bare command-name matches only count at argv0. Later args must be path-like
+/// (contain `/`) to avoid treating arbitrary positional data as an agent
+/// executable.
 fn check_via_cmdline(
     pid: u32,
-    path_matches: fn(&str) -> bool,
-    harness: Harness,
+    definition: &'static HarnessDefinition,
 ) -> Option<DiscoveredProcess> {
     let cmdline_path = format!("/proc/{pid}/cmdline");
     let cmdline_bytes = std::fs::read(&cmdline_path).ok()?;
@@ -400,19 +356,37 @@ fn check_via_cmdline(
         .split(|&b| b == 0)
         .filter_map(|bytes| std::str::from_utf8(bytes).ok())
         .filter(|s| !s.is_empty())
-        .any(|arg| {
+        .enumerate()
+        .any(|(index, arg)| {
             // Skip flag arguments (e.g. --config)
             if arg.starts_with('-') {
                 return false;
             }
-            path_matches(arg)
+            cmdline_arg_matches_definition(index, arg, definition)
         });
 
     if !matched {
         return None;
     }
 
-    get_process_info(pid, harness)
+    get_process_info(pid, definition.harness)
+}
+
+/// Returns true if one cmdline argument can identify a harness.
+fn cmdline_arg_matches_definition(
+    index: usize,
+    arg: &str,
+    definition: &'static HarnessDefinition,
+) -> bool {
+    let is_argv0 = index == 0;
+    let is_path_like = arg.contains('/');
+    if !is_path_like && (!is_argv0 || !definition.allow_bare_cmdline_match) {
+        return false;
+    }
+    definition
+        .process_matchers
+        .iter()
+        .any(|matcher| matcher.matches(arg))
 }
 
 /// Gets process info (cwd, tmux pane) for a PID.
@@ -654,41 +628,94 @@ mod tests {
     }
 
     // ========================================================================
-    // Tests for is_claude_path helper
+    // Tests for registry-backed process matching
     // ========================================================================
 
-    #[test]
-    fn test_is_claude_path_absolute_path() {
-        assert!(is_claude_path("/usr/local/bin/claude"));
-        assert!(is_claude_path("/home/user/.local/bin/claude"));
+    fn matches_harness_path(harness_id: &str, path: &str) -> bool {
+        atm_core::find_harness_definition(harness_id)
+            .map(|definition| {
+                definition
+                    .process_matchers
+                    .iter()
+                    .any(|matcher| matcher.matches(path))
+            })
+            .unwrap_or(false)
     }
 
     #[test]
-    fn test_is_claude_path_bare_command() {
-        assert!(is_claude_path("claude"));
+    fn test_claude_registry_matcher_absolute_path() {
+        assert!(matches_harness_path("claude", "/usr/local/bin/claude"));
+        assert!(matches_harness_path(
+            "claude",
+            "/home/user/.local/bin/claude"
+        ));
     }
 
     #[test]
-    fn test_is_claude_path_versioned_install() {
-        assert!(is_claude_path(
+    fn test_claude_registry_matcher_bare_command() {
+        assert!(matches_harness_path("claude", "claude"));
+    }
+
+    #[test]
+    fn test_claude_registry_matcher_versioned_install() {
+        assert!(matches_harness_path(
+            "claude",
             "/home/user/.local/share/claude/versions/1.2.3/claude"
         ));
-        assert!(is_claude_path("~/.local/share/claude/versions/0.5.0/node"));
+        assert!(matches_harness_path(
+            "claude",
+            "~/.local/share/claude/versions/0.5.0/node"
+        ));
     }
 
     #[test]
-    fn test_is_claude_path_rejects_non_claude() {
-        assert!(!is_claude_path("/usr/bin/bash"));
-        assert!(!is_claude_path("vim"));
-        assert!(!is_claude_path("/home/user/claudette")); // not ending with /claude
-        assert!(!is_claude_path("claude-dev")); // not exact match
+    fn test_claude_registry_matcher_rejects_non_claude() {
+        assert!(!matches_harness_path("claude", "/usr/bin/bash"));
+        assert!(!matches_harness_path("claude", "vim"));
+        assert!(!matches_harness_path("claude", "/home/user/claudette"));
+        assert!(!matches_harness_path("claude", "claude-dev"));
     }
 
     #[test]
-    fn test_is_claude_path_edge_cases() {
-        // Path that contains "claude" but not at the end or in versions
-        assert!(!is_claude_path("/home/claudeuser/bin/tool"));
-        // Empty string
-        assert!(!is_claude_path(""));
+    fn test_pi_registry_matcher_rejects_bare_cmdline_match() {
+        let pi = atm_core::find_harness_definition("pi");
+        assert!(pi.is_some_and(|definition| !definition.allow_bare_cmdline_match));
+        assert!(matches_harness_path("pi", "/usr/bin/pi"));
+        assert!(!matches_harness_path("pi", "not-pi"));
+    }
+
+    #[test]
+    fn test_cmdline_matching_only_allows_bare_match_on_argv0() {
+        let claude = atm_core::find_harness_definition("claude")
+            .unwrap_or_else(atm_core::default_harness_definition);
+        assert!(cmdline_arg_matches_definition(0, "claude", claude));
+        assert!(!cmdline_arg_matches_definition(1, "claude", claude));
+        assert!(cmdline_arg_matches_definition(
+            1,
+            "/usr/local/bin/claude",
+            claude
+        ));
+    }
+
+    #[test]
+    fn test_cmdline_matching_rejects_bare_pi_positional_arg() {
+        let pi = atm_core::find_harness_definition("pi")
+            .unwrap_or_else(atm_core::default_harness_definition);
+        assert!(!cmdline_arg_matches_definition(0, "pi", pi));
+        assert!(!cmdline_arg_matches_definition(2, "pi", pi));
+        assert!(cmdline_arg_matches_definition(
+            1,
+            "/home/user/.npm/pi-coding-agent/bin/pi.js",
+            pi
+        ));
+    }
+
+    #[test]
+    fn test_only_adapter_backed_harnesses_are_discovery_enabled() {
+        let enabled: Vec<&str> = atm_core::builtin_harnesses()
+            .filter(|definition| definition.discovery_enabled)
+            .map(|definition| definition.id)
+            .collect();
+        assert_eq!(enabled, vec!["claude", "pi"]);
     }
 }

--- a/src/bin/atm.rs
+++ b/src/bin/atm.rs
@@ -1,13 +1,13 @@
 //! ATM — Agent Tmux Manager
 //!
-//! CLI + TUI for managing Claude Code agents in tmux.
+//! CLI + TUI for managing coding agents in tmux.
 //!
 //! # Usage
 //!
 //! ```text
 //! atm                        # Launch TUI dashboard
 //! atm --pick                 # Pick mode - exit after jumping to a session
-//! atm spawn                  # Spawn a new Claude agent
+//! atm spawn                  # Spawn a new coding agent
 //! atm kill <session-id>      # Kill an agent
 //! atm interrupt <session-id> # Send SIGINT to an agent
 //! atm send <session-id> <text> # Send text to agent pane
@@ -17,7 +17,7 @@
 //! atm uninstall              # Remove hooks
 //! ```
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::fs::{self, OpenOptions};
 use std::io::{self, Stdout};
 use std::path::PathBuf;
@@ -32,6 +32,7 @@ use crossterm::{
     terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
 };
 use ratatui::{backend::CrosstermBackend, Terminal};
+use serde::Deserialize;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::net::UnixStream;
 use tokio::sync::mpsc;
@@ -39,7 +40,10 @@ use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, info, warn};
 use tracing_subscriber::EnvFilter;
 
-use atm_core::SessionView;
+use atm_core::{
+    builtin_harnesses, default_harness_definition, find_harness_definition, HarnessDefinition,
+    SessionView,
+};
 use atm_protocol::{ClientMessage, DaemonMessage};
 use atm_tmux::{RealTmuxClient, TmuxClient};
 use atm_tui::app::App;
@@ -56,10 +60,10 @@ use atm_tui::ui;
 // CLI Arguments
 // ============================================================================
 
-/// ATM — Agent Tmux Manager for Claude Code
+/// ATM — Agent Tmux Manager for coding-agent harnesses
 #[derive(Parser, Debug)]
 #[command(name = "atm")]
-#[command(about = "Manage Claude Code agents in tmux")]
+#[command(about = "Manage coding agents in tmux")]
 #[command(version)]
 struct Args {
     #[command(subcommand)]
@@ -80,12 +84,15 @@ struct Args {
 
 #[derive(Subcommand, Debug)]
 enum Command {
-    /// Configure Claude Code hooks for atm
+    /// Configure supported harness integrations for atm
     Setup,
-    /// Remove atm hooks from Claude Code
+    /// Remove atm integrations from supported harnesses
     Uninstall,
-    /// Spawn a new Claude Code agent in a tmux pane
+    /// Spawn a coding agent in a tmux pane
     Spawn {
+        /// Harness to launch (e.g., claude, pi, codex, amp, qwen, gemini). Defaults to [harness].default in config, or claude.
+        #[arg(long = "harness", short = 'H')]
+        harness: Option<String>,
         /// Model to use (e.g., opus, sonnet, haiku)
         #[arg(long, short = 'm')]
         model: Option<String>,
@@ -786,44 +793,260 @@ fn shell_quote(s: &str) -> String {
 
 /// Build the shell command string sent to a freshly-split tmux pane.
 ///
-/// Honors two environment variables (both treat empty as unset):
+/// Honors spawn override environment variables (all treat empty as unset):
 ///
-/// - `ATM_SPAWN_BIN`: an absolute (or PATH-resolvable) path to the
-///   claude binary. Useful for wrapped installs (e.g. macOS app bundle
-///   at `/Applications/Claude Code.app/Contents/MacOS/claude`) and for
-///   integration tests that inject a fixture. The value is shell-quoted
-///   as one token, so spaces/specials in the path "just work."
+/// - `ATM_SPAWN_<HARNESS>_BIN` / `ATM_SPAWN_<HARNESS>_ARGS`: harness-specific
+///   overrides, where `<HARNESS>` is the canonical id uppercased with `-`
+///   replaced by `_` (for example `ATM_SPAWN_PI_BIN=mise` and
+///   `ATM_SPAWN_PI_ARGS='x pi'`). Use these when one harness needs a custom
+///   launcher without changing other harnesses.
 ///
-/// - `ATM_SPAWN_ARGS`: extra arguments inserted *between* the bin and
-///   the appended `--model` flag. Use this for wrapper commands like
-///   `mise x claude` (`ATM_SPAWN_BIN=mise ATM_SPAWN_ARGS='x claude'`)
-///   or `env FOO=1 claude` (`ATM_SPAWN_BIN=env
-///   ATM_SPAWN_ARGS='FOO=1 claude'`). The value is interpolated
-///   *verbatim*, not re-quoted — that's the whole point, since the
-///   user's intent is multi-token. The user is responsible for quoting
-///   anything inside `ATM_SPAWN_ARGS` that needs to be one token (same
-///   contract as `bash -c "..."`).
+/// - `ATM_SPAWN_BIN` / `ATM_SPAWN_ARGS`: legacy global overrides used when the
+///   harness-specific variables are unset. These intentionally override the
+///   selected harness command and are mainly for tests or whole-install wrappers.
+///
+/// `*_BIN` is shell-quoted as one token, so spaces/specials in a path "just
+/// work." `*_ARGS` is inserted *between* the bin and appended model flag and is
+/// interpolated verbatim — the user's intent is multi-token wrapper syntax. The
+/// user is responsible for quoting anything inside `*_ARGS` that needs to be
+/// one token (same contract as `bash -c "..."`).
 ///
 /// `cwd` and `model` go through `shell_quote`, so a model name like
 /// `opus 4.5` or a cwd with spaces compose safely without the caller
 /// thinking about it.
-fn build_spawn_command(cwd: Option<&str>, model: Option<&str>) -> String {
-    let base = std::env::var("ATM_SPAWN_BIN")
-        .ok()
-        .filter(|s| !s.is_empty())
-        .unwrap_or_else(|| "claude".to_string());
-    let mut cmd = shell_quote(&base);
+#[derive(Debug, Clone, Default, Deserialize)]
+struct AtmConfig {
+    #[serde(default)]
+    harness: HarnessConfig,
+}
 
-    if let Some(args) = std::env::var("ATM_SPAWN_ARGS")
-        .ok()
-        .filter(|s| !s.is_empty())
-    {
+#[derive(Debug, Clone, Default, Deserialize)]
+struct HarnessConfig {
+    /// Default harness id/alias used when `atm spawn` omits `--harness`.
+    default: Option<String>,
+    /// Per-harness spawn overrides from `[harness.<name>]` tables.
+    #[serde(flatten)]
+    definitions: HashMap<String, HarnessTomlConfig>,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+struct HarnessTomlConfig {
+    /// Binary or wrapper command to launch.
+    binary: Option<String>,
+    /// Default arguments inserted after `binary` and before any model flag.
+    default_args: Option<Vec<String>>,
+    /// Optional model flag override. Empty string disables model support.
+    model_flag: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+struct SpawnHarnessDefinition {
+    id: String,
+    binary: String,
+    default_args: Vec<String>,
+    model_flag: Option<String>,
+}
+
+impl SpawnHarnessDefinition {
+    fn from_builtin(definition: &HarnessDefinition) -> Self {
+        Self {
+            id: definition.id.to_string(),
+            binary: definition.binary.to_string(),
+            default_args: definition
+                .default_args
+                .iter()
+                .map(|arg| (*arg).to_string())
+                .collect(),
+            model_flag: definition.model_flag.map(str::to_string),
+        }
+    }
+
+    fn from_custom(id: &str, config: &HarnessTomlConfig) -> Result<Self> {
+        let binary = config
+            .binary
+            .as_deref()
+            .filter(|s| !s.is_empty())
+            .ok_or_else(|| anyhow::anyhow!("custom harness '{id}' requires binary"))?;
+        Ok(Self {
+            id: id.to_string(),
+            binary: binary.to_string(),
+            default_args: config.default_args.clone().unwrap_or_default(),
+            model_flag: config.model_flag.as_deref().and_then(non_empty_str),
+        })
+    }
+
+    fn apply_config(&mut self, config: &HarnessTomlConfig) {
+        if let Some(binary) = config.binary.as_deref().filter(|s| !s.is_empty()) {
+            self.binary = binary.to_string();
+        }
+        if let Some(args) = &config.default_args {
+            self.default_args.clone_from(args);
+        }
+        if let Some(flag) = &config.model_flag {
+            self.model_flag = non_empty_str(flag);
+        }
+    }
+}
+
+fn non_empty_str(s: &str) -> Option<String> {
+    if s.is_empty() {
+        None
+    } else {
+        Some(s.to_string())
+    }
+}
+
+fn config_path() -> Option<PathBuf> {
+    dirs::config_dir().map(|dir| dir.join("atm/config.toml"))
+}
+
+fn default_config_text() -> &'static str {
+    r#"# ATM configuration
+#
+# The default harness is used when `atm spawn` omits `--harness`.
+[harness]
+default = "claude"
+
+# Per-harness defaults override built-ins when no env override is set.
+# Environment precedence: ATM_SPAWN_<HARNESS>_BIN/ARGS, then
+# ATM_SPAWN_BIN/ARGS, then this file, then built-in defaults.
+#
+# Example: make `atm spawn` launch pi through mise:
+# [harness]
+# default = "pi"
+#
+# [harness.pi]
+# binary = "mise"
+# default_args = ["x", "pi"]
+#
+# Example: define a custom harness:
+# [harness.custom]
+# binary = "custom-agent"
+# default_args = ["--profile", "atm"]
+# model_flag = "--model-id"
+"#
+}
+
+fn ensure_default_config_file(path: &std::path::Path) -> Result<()> {
+    if path.exists() {
+        return Ok(());
+    }
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("Failed to create config directory {}", parent.display()))?;
+    }
+    fs::write(path, default_config_text())
+        .with_context(|| format!("Failed to write default config {}", path.display()))
+}
+
+fn load_atm_config() -> Result<AtmConfig> {
+    let Some(path) = config_path() else {
+        return Ok(AtmConfig::default());
+    };
+    if !path.exists() {
+        if let Err(e) = ensure_default_config_file(&path) {
+            warn!(
+                error = %e,
+                path = %path.display(),
+                "Failed to create default config; continuing with built-in defaults"
+            );
+            return Ok(AtmConfig::default());
+        }
+    }
+    let content = fs::read_to_string(&path)
+        .with_context(|| format!("Failed to read config {}", path.display()))?;
+    toml::from_str(&content).with_context(|| format!("Failed to parse config {}", path.display()))
+}
+
+fn resolve_spawn_harness(harness_id: Option<&str>) -> Result<SpawnHarnessDefinition> {
+    let config = load_atm_config()?;
+    let requested = harness_id
+        .or(config.harness.default.as_deref())
+        .unwrap_or(default_harness_definition().id);
+
+    if let Some(builtin) = find_harness_definition(requested) {
+        let mut definition = SpawnHarnessDefinition::from_builtin(builtin);
+        if let Some(overlay) = config.harness.definitions.get(builtin.id) {
+            definition.apply_config(overlay);
+        }
+        if let Some(overlay) = config.harness.definitions.get(requested) {
+            definition.apply_config(overlay);
+        }
+        return Ok(definition);
+    }
+
+    if let Some(custom) = config.harness.definitions.get(requested) {
+        return SpawnHarnessDefinition::from_custom(requested, custom);
+    }
+
+    bail!(
+        "unknown harness '{requested}' (available: {})",
+        available_harness_ids_display(&config)
+    )
+}
+
+fn available_harness_ids_display(config: &AtmConfig) -> String {
+    let mut ids: Vec<String> = builtin_harnesses()
+        .map(|definition| definition.id.to_string())
+        .collect();
+    let mut custom_ids: Vec<String> = config.harness.definitions.keys().cloned().collect();
+    custom_ids.sort();
+    for id in custom_ids {
+        if !ids.iter().any(|existing| existing == &id) {
+            ids.push(id);
+        }
+    }
+    ids.join(", ")
+}
+
+fn build_spawn_command(cwd: Option<&str>, model: Option<&str>) -> String {
+    let harness = resolve_spawn_harness(None).unwrap_or_else(|e| {
+        warn!(error = %e, "Failed to load spawn harness config; using built-in default");
+        SpawnHarnessDefinition::from_builtin(default_harness_definition())
+    });
+    build_spawn_command_for_harness(&harness, cwd, model)
+}
+
+fn harness_spawn_env_key(harness: &SpawnHarnessDefinition, suffix: &str) -> String {
+    format!(
+        "ATM_SPAWN_{}_{}",
+        harness.id.replace('-', "_").to_ascii_uppercase(),
+        suffix
+    )
+}
+
+fn non_empty_env(key: &str) -> Option<String> {
+    std::env::var(key).ok().filter(|s| !s.is_empty())
+}
+
+fn spawn_env_override(harness: &SpawnHarnessDefinition, suffix: &str) -> Option<String> {
+    let harness_key = harness_spawn_env_key(harness, suffix);
+    non_empty_env(&harness_key).or_else(|| non_empty_env(&format!("ATM_SPAWN_{suffix}")))
+}
+
+fn build_spawn_command_for_harness(
+    harness: &SpawnHarnessDefinition,
+    cwd: Option<&str>,
+    model: Option<&str>,
+) -> String {
+    let spawn_bin = spawn_env_override(harness, "BIN");
+    let base = spawn_bin.as_deref().unwrap_or(&harness.binary);
+    let mut cmd = shell_quote(base);
+
+    if spawn_bin.is_none() {
+        for arg in &harness.default_args {
+            cmd.push(' ');
+            cmd.push_str(&shell_quote(arg));
+        }
+    }
+
+    if let Some(args) = spawn_env_override(harness, "ARGS") {
         cmd.push(' ');
         cmd.push_str(args.trim());
     }
 
-    if let Some(m) = model {
-        cmd.push_str(&format!(" --model {}", shell_quote(m)));
+    if let (Some(flag), Some(m)) = (harness.model_flag.as_deref(), model) {
+        cmd.push_str(&format!(" {flag} {}", shell_quote(m)));
     }
     if let Some(dir) = cwd {
         cmd = format!("cd {} && {cmd}", shell_quote(dir));
@@ -832,12 +1055,18 @@ fn build_spawn_command(cwd: Option<&str>, model: Option<&str>) -> String {
 }
 
 async fn cmd_spawn(
+    harness_id: Option<String>,
     model: Option<String>,
     worktree: Option<String>,
     direction: SpawnDirection,
     size: String,
     target_pane: Option<String>,
 ) -> Result<()> {
+    let harness = resolve_spawn_harness(harness_id.as_deref())?;
+    if model.is_some() && harness.model_flag.is_none() {
+        bail!("harness '{}' does not support --model yet", harness.id);
+    }
+
     if !tmux::is_in_tmux() {
         bail!("atm spawn requires running inside tmux");
     }
@@ -877,7 +1106,7 @@ async fn cmd_spawn(
             })
     };
 
-    let claude_cmd = build_spawn_command(cwd.as_deref(), model.as_deref());
+    let agent_cmd = build_spawn_command_for_harness(&harness, cwd.as_deref(), model.as_deref());
 
     let pane_dir: atm_tmux::PaneDirection = direction.into();
     // Split without a command so the pane gets an interactive shell (which has
@@ -889,7 +1118,7 @@ async fn cmd_spawn(
         .context("Failed to split tmux pane")?;
 
     client
-        .send_keys(&new_pane, &claude_cmd)
+        .send_keys(&new_pane, &agent_cmd)
         .await
         .context("Failed to send command to new pane")?;
     client
@@ -1812,13 +2041,14 @@ async fn main() -> Result<()> {
             return setup::uninstall();
         }
         Some(Command::Spawn {
+            harness,
             model,
             worktree,
             direction,
             size,
             target_pane,
         }) => {
-            return cmd_spawn(model, worktree, direction, size, target_pane).await;
+            return cmd_spawn(harness, model, worktree, direction, size, target_pane).await;
         }
         Some(Command::Kill { target }) => {
             return cmd_kill(target).await;
@@ -1996,6 +2226,71 @@ async fn main() -> Result<()> {
 }
 
 #[cfg(test)]
+mod cli_tests {
+    use super::{resolve_spawn_harness, Args, Command};
+    use clap::Parser;
+
+    struct IsolatedConfigHome {
+        _dir: tempfile::TempDir,
+        prev: Option<std::ffi::OsString>,
+    }
+
+    impl IsolatedConfigHome {
+        fn new() -> Self {
+            let dir = tempfile::tempdir().unwrap_or_else(|e| panic!("{e}"));
+            let prev = std::env::var_os("XDG_CONFIG_HOME");
+            std::env::set_var("XDG_CONFIG_HOME", dir.path());
+            Self { _dir: dir, prev }
+        }
+    }
+
+    impl Drop for IsolatedConfigHome {
+        fn drop(&mut self) {
+            match self.prev.take() {
+                Some(v) => std::env::set_var("XDG_CONFIG_HOME", v),
+                None => std::env::remove_var("XDG_CONFIG_HOME"),
+            }
+        }
+    }
+
+    #[test]
+    fn spawn_harness_defaults_to_config_resolution() {
+        let args = Args::try_parse_from(["atm", "spawn"]).unwrap_or_else(|e| panic!("{e}"));
+        match args.command {
+            Some(Command::Spawn { harness, .. }) => assert!(harness.is_none()),
+            other => panic!("expected spawn command, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn spawn_harness_parses_long_and_short_flags() {
+        let args = Args::try_parse_from(["atm", "spawn", "--harness", "pi"])
+            .unwrap_or_else(|e| panic!("{e}"));
+        match args.command {
+            Some(Command::Spawn { harness, .. }) => assert_eq!(harness.as_deref(), Some("pi")),
+            other => panic!("expected spawn command, got {other:?}"),
+        }
+
+        let args =
+            Args::try_parse_from(["atm", "spawn", "-H", "codex"]).unwrap_or_else(|e| panic!("{e}"));
+        match args.command {
+            Some(Command::Spawn { harness, .. }) => assert_eq!(harness.as_deref(), Some("codex")),
+            other => panic!("expected spawn command, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn resolve_spawn_harness_reports_available_ids() {
+        let _config_home = IsolatedConfigHome::new();
+        let err = resolve_spawn_harness(Some("nope")).unwrap_err();
+        let message = err.to_string();
+        assert!(message.contains("unknown harness 'nope'"));
+        assert!(message.contains("claude"));
+        assert!(message.contains("pi"));
+    }
+}
+
+#[cfg(test)]
 mod prompt_tests {
     use super::extract_prompt;
 
@@ -2073,7 +2368,8 @@ mod prompt_tests {
 
 #[cfg(test)]
 mod spawn_command_tests {
-    use super::build_spawn_command;
+    use super::{build_spawn_command, build_spawn_command_for_harness, resolve_spawn_harness};
+    use std::fs;
 
     /// RAII guard that captures an env var's current value on construction
     /// and restores it on drop (including during unwinding from a failed
@@ -2109,23 +2405,32 @@ mod spawn_command_tests {
     }
 
     /// One single `#[test]`, because all the cases mutate process-global
-    /// env vars (`ATM_SPAWN_BIN` and `ATM_SPAWN_ARGS`), and Rust's
-    /// default test runner runs tests in parallel. Splitting would race.
+    /// spawn env vars, and Rust's default test runner runs tests in parallel.
+    /// Splitting would race.
     /// (`serial_test` would solve that but isn't worth a dep just here.)
     #[test]
     fn build_spawn_command_cases() {
         let bin = EnvGuard::capture("ATM_SPAWN_BIN");
         let args = EnvGuard::capture("ATM_SPAWN_ARGS");
+        let pi_bin = EnvGuard::capture("ATM_SPAWN_PI_BIN");
+        let pi_args = EnvGuard::capture("ATM_SPAWN_PI_ARGS");
+        let config_home = EnvGuard::capture("XDG_CONFIG_HOME");
+        let config_dir = tempfile::tempdir().unwrap_or_else(|e| panic!("{e}"));
 
-        // Start clean — captured `bin` and `args` will be restored on
-        // drop regardless of which scenarios run/panic below.
+        // Start clean — captured env vars will be restored on drop regardless
+        // of which scenarios run/panic below.
         bin.unset();
         args.unset();
+        pi_bin.unset();
+        pi_args.unset();
+        std::env::set_var("XDG_CONFIG_HOME", config_dir.path());
 
-        // 1. Unset env → default to single-quoted "claude".
+        // 1. Unset env/config → default to single-quoted "claude" and
+        //    auto-create a starter config file.
         //    `'claude'` is identical to bare `claude` for execve;
         //    quoting just removes shell-parsing surprises elsewhere.
         assert_eq!(build_spawn_command(None, None), "'claude'");
+        assert!(config_dir.path().join("atm/config.toml").exists());
 
         // 2. Empty value is treated as unset.
         bin.set("");
@@ -2201,7 +2506,73 @@ mod spawn_command_tests {
             "cd '/work/dir' && 'direnv' exec . claude --model 'opus'"
         );
 
+        // 13. Explicit harness selection changes the launched binary while
+        //     retaining model/cwd composition.
+        bin.unset();
+        args.unset();
+        let pi = resolve_spawn_harness(Some("pi")).unwrap_or_else(|e| panic!("{e}"));
+        assert_eq!(
+            build_spawn_command_for_harness(&pi, Some("/work/dir"), Some("gpt-5.5")),
+            "cd '/work/dir' && 'pi' --model 'gpt-5.5'"
+        );
+
+        let codex = resolve_spawn_harness(Some("codex")).unwrap_or_else(|e| panic!("{e}"));
+        assert_eq!(
+            build_spawn_command_for_harness(&codex, None, None),
+            "'codex'"
+        );
+
+        // 14. Harness-specific overrides take precedence over the legacy
+        //     global overrides, so users can customize one harness without
+        //     changing every `atm spawn --harness ...` invocation.
+        bin.set("global-bin");
+        args.set("global args");
+        pi_bin.set("mise");
+        pi_args.set("x pi");
+        assert_eq!(
+            build_spawn_command_for_harness(&pi, None, Some("gpt-5.5")),
+            "'mise' x pi --model 'gpt-5.5'"
+        );
+
+        // 15. Without a harness-specific override, legacy globals still apply
+        //     as an intentional whole-command override.
+        pi_bin.unset();
+        pi_args.unset();
+        assert_eq!(
+            build_spawn_command_for_harness(&pi, None, None),
+            "'global-bin' global args"
+        );
+
+        // 16. Config can set the default harness and per-harness spawn defaults.
+        bin.unset();
+        args.unset();
+        let atm_config_dir = config_dir.path().join("atm");
+        fs::create_dir_all(&atm_config_dir).unwrap_or_else(|e| panic!("{e}"));
+        fs::write(
+            atm_config_dir.join("config.toml"),
+            "[harness]\ndefault = 'pi'\n\n[harness.pi]\nbinary = 'mise'\ndefault_args = ['x', 'pi']\n",
+        )
+        .unwrap_or_else(|e| panic!("{e}"));
+        assert_eq!(
+            build_spawn_command(None, Some("gpt-5.5")),
+            "'mise' 'x' 'pi' --model 'gpt-5.5'"
+        );
+
+        // 17. Config can define a custom harness.
+        fs::write(
+            atm_config_dir.join("config.toml"),
+            "[harness.custom]\nbinary = 'custom-agent'\ndefault_args = ['--profile', 'atm']\nmodel_flag = '--model-id'\n",
+        )
+        .unwrap_or_else(|e| panic!("{e}"));
+        let custom = resolve_spawn_harness(Some("custom")).unwrap_or_else(|e| panic!("{e}"));
+        assert_eq!(
+            build_spawn_command_for_harness(&custom, None, Some("abc")),
+            "'custom-agent' '--profile' 'atm' --model-id 'abc'"
+        );
+
         // env's Drop restores the captured values, even if any of the
         // assert_eq!s above panicked.
+        let _ = config_home;
+        let _ = config_dir;
     }
 }


### PR DESCRIPTION
## Summary
- add a built-in harness registry in atm-core for claude, pi, codex, amp, qwen, and gemini
- add `atm spawn --harness <id>` with aliases and harness-specific spawn env overrides (`ATM_SPAWN_<HARNESS>_BIN/ARGS`)
- make daemon process discovery consume registry metadata while only auto-discovering adapter-backed harnesses (claude/pi)
- harden Harness serde/API forward compatibility and update README wording

## Safety notes
- bare cmdline matches are only accepted on argv[0], never arbitrary positional args
- codex/amp/qwen/gemini are spawn-known but not discovery-enabled until adapters/status sources exist
- `--model` is only supported for harnesses with verified model flags (claude/pi)

## Tests
- `cargo test --workspace --no-run`
- `cargo clippy --workspace -- -D warnings`
- targeted tests: `cargo test -p atm spawn_command_tests`, `cargo test -p atm cli_tests`, `cargo test -p atm-core harness_registry::tests`, `cargo test -p atmd discovery::tests`

Refs agent-tmux-manager-96y