### PR TITLE
refactor: move atm config.toml auto-creation from spawn to setup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -202,6 +202,7 @@ dependencies = [
  "ratatui",
  "serde",
  "serde_json",
+ "tempfile",
  "thiserror",
  "tokio",
  "tokio-util",

--- a/crates/atm/Cargo.toml
+++ b/crates/atm/Cargo.toml
@@ -34,4 +34,5 @@ dirs = "5.0"
 
 [dev-dependencies]
 insta = { workspace = true }
+tempfile = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros", "test-util"] }

--- a/crates/atm/src/setup.rs
+++ b/crates/atm/src/setup.rs
@@ -13,6 +13,7 @@
 //!   Mirrors how pi-amplike documents local-dev installs.
 
 use std::fs;
+use std::io::ErrorKind;
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
@@ -403,6 +404,58 @@ fn remove_hook_script() -> Result<bool> {
     }
 }
 
+/// Returns the path to atm's own configuration file (`$XDG_CONFIG_HOME/atm/config.toml`).
+pub fn atm_config_path() -> Option<PathBuf> {
+    dirs::config_dir().map(|dir| dir.join("atm/config.toml"))
+}
+
+fn default_atm_config_text() -> &'static str {
+    r#"# ATM configuration
+#
+# The default harness is used when `atm spawn` omits `--harness`.
+[harness]
+default = "claude"
+
+# Per-harness defaults override built-ins when no env override is set.
+# Environment precedence: ATM_SPAWN_<HARNESS>_BIN/ARGS, then
+# ATM_SPAWN_BIN/ARGS, then this file, then built-in defaults.
+#
+# Example: make `atm spawn` launch pi through mise:
+# [harness]
+# default = "pi"
+#
+# [harness.pi]
+# binary = "mise"
+# default_args = ["x", "pi"]
+#
+# Example: define a custom harness:
+# [harness.custom]
+# binary = "custom-agent"
+# default_args = ["--profile", "atm"]
+# model_flag = "--model-id"
+"#
+}
+
+/// Writes the default atm config to `path` if it does not already exist.
+///
+/// Idempotent: an existing file is left untouched so user edits are preserved.
+/// Reports back whether the file was newly created.
+pub fn ensure_default_atm_config(path: &Path) -> Result<bool> {
+    if path.exists() {
+        return Ok(false);
+    }
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("Failed to create config directory {}", parent.display()))?;
+    }
+    match fs::write(path, default_atm_config_text()) {
+        Ok(()) => Ok(true),
+        // Lost a race with another writer — treat as already-present.
+        Err(e) if e.kind() == ErrorKind::AlreadyExists => Ok(false),
+        Err(e) => Err(e).with_context(|| format!("Failed to write default config {}", path.display())),
+    }
+}
+
 /// Installs atm integration for every detected coding-agent harness.
 pub fn setup() -> Result<()> {
     println!("Setting up ATM...\n");
@@ -440,6 +493,17 @@ pub fn setup() -> Result<()> {
     // Step N: Install tmux keybindings (vendor-neutral).
     println!();
     install_tmux_bindings()?;
+
+    // Step N+1: Materialize atm's own config.toml so users have a documented
+    // starting point. Spawn no longer auto-creates this; setup is the only
+    // writer.
+    if let Some(path) = atm_config_path() {
+        print!("\nWriting atm config to {}... ", path.display());
+        match ensure_default_atm_config(&path)? {
+            true => println!("created"),
+            false => println!("already present (preserved)"),
+        }
+    }
 
     println!("\nNext step:");
     println!("  Run: atm");
@@ -601,4 +665,48 @@ pub fn uninstall() -> Result<()> {
 
     println!("\nATM uninstalled successfully!");
     Ok(())
+}
+
+#[cfg(test)]
+mod config_tests {
+    use super::{default_atm_config_text, ensure_default_atm_config};
+    use std::fs;
+
+    #[test]
+    fn creates_config_when_absent() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("nested/config.toml");
+
+        let created = ensure_default_atm_config(&path).unwrap();
+
+        assert!(created, "expected newly-created config to report true");
+        let on_disk = fs::read_to_string(&path).unwrap();
+        assert_eq!(on_disk, default_atm_config_text());
+    }
+
+    #[test]
+    fn preserves_existing_user_edits() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        let user_content = "[harness]\ndefault = \"pi\"\n# my custom edits\n";
+        fs::write(&path, user_content).unwrap();
+
+        let created = ensure_default_atm_config(&path).unwrap();
+
+        assert!(!created, "existing file must not be reported as created");
+        let on_disk = fs::read_to_string(&path).unwrap();
+        assert_eq!(on_disk, user_content, "user edits must be preserved");
+    }
+
+    #[test]
+    fn second_call_is_noop() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+
+        let first = ensure_default_atm_config(&path).unwrap();
+        let second = ensure_default_atm_config(&path).unwrap();
+
+        assert!(first);
+        assert!(!second);
+    }
 }

--- a/crates/atm/src/setup.rs
+++ b/crates/atm/src/setup.rs
@@ -452,7 +452,9 @@ pub fn ensure_default_atm_config(path: &Path) -> Result<bool> {
         Ok(()) => Ok(true),
         // Lost a race with another writer — treat as already-present.
         Err(e) if e.kind() == ErrorKind::AlreadyExists => Ok(false),
-        Err(e) => Err(e).with_context(|| format!("Failed to write default config {}", path.display())),
+        Err(e) => {
+            Err(e).with_context(|| format!("Failed to write default config {}", path.display()))
+        }
     }
 }
 

--- a/src/bin/atm.rs
+++ b/src/bin/atm.rs
@@ -899,62 +899,14 @@ fn non_empty_str(s: &str) -> Option<String> {
     }
 }
 
-fn config_path() -> Option<PathBuf> {
-    dirs::config_dir().map(|dir| dir.join("atm/config.toml"))
-}
-
-fn default_config_text() -> &'static str {
-    r#"# ATM configuration
-#
-# The default harness is used when `atm spawn` omits `--harness`.
-[harness]
-default = "claude"
-
-# Per-harness defaults override built-ins when no env override is set.
-# Environment precedence: ATM_SPAWN_<HARNESS>_BIN/ARGS, then
-# ATM_SPAWN_BIN/ARGS, then this file, then built-in defaults.
-#
-# Example: make `atm spawn` launch pi through mise:
-# [harness]
-# default = "pi"
-#
-# [harness.pi]
-# binary = "mise"
-# default_args = ["x", "pi"]
-#
-# Example: define a custom harness:
-# [harness.custom]
-# binary = "custom-agent"
-# default_args = ["--profile", "atm"]
-# model_flag = "--model-id"
-"#
-}
-
-fn ensure_default_config_file(path: &std::path::Path) -> Result<()> {
-    if path.exists() {
-        return Ok(());
-    }
-    if let Some(parent) = path.parent() {
-        fs::create_dir_all(parent)
-            .with_context(|| format!("Failed to create config directory {}", parent.display()))?;
-    }
-    fs::write(path, default_config_text())
-        .with_context(|| format!("Failed to write default config {}", path.display()))
-}
-
 fn load_atm_config() -> Result<AtmConfig> {
-    let Some(path) = config_path() else {
+    let Some(path) = setup::atm_config_path() else {
         return Ok(AtmConfig::default());
     };
     if !path.exists() {
-        if let Err(e) = ensure_default_config_file(&path) {
-            warn!(
-                error = %e,
-                path = %path.display(),
-                "Failed to create default config; continuing with built-in defaults"
-            );
-            return Ok(AtmConfig::default());
-        }
+        // Missing config is not an error: fall back to built-in defaults silently.
+        // `atm setup` is the only writer of this file.
+        return Ok(AtmConfig::default());
     }
     let content = fs::read_to_string(&path)
         .with_context(|| format!("Failed to read config {}", path.display()))?;
@@ -2299,6 +2251,26 @@ mod cli_tests {
         assert!(message.contains("claude"));
         assert!(message.contains("pi"));
     }
+
+    #[test]
+    fn load_atm_config_is_silent_when_file_absent() {
+        let config_home = IsolatedConfigHome::new();
+        let expected_path = super::setup::atm_config_path()
+            .expect("XDG_CONFIG_HOME is set, atm_config_path should resolve");
+
+        let config = super::load_atm_config().unwrap_or_else(|e| panic!("{e}"));
+
+        assert!(
+            !expected_path.exists(),
+            "load_atm_config must not create {} as a side effect",
+            expected_path.display()
+        );
+        assert!(
+            config.harness.default.is_none(),
+            "missing config file should yield default AtmConfig"
+        );
+        drop(config_home);
+    }
 }
 
 #[cfg(test)]
@@ -2439,12 +2411,16 @@ mod spawn_command_tests {
         pi_args.unset();
         std::env::set_var("XDG_CONFIG_HOME", config_dir.path());
 
-        // 1. Unset env/config → default to single-quoted "claude" and
-        //    auto-create a starter config file.
+        // 1. Unset env/config → default to single-quoted "claude".
         //    `'claude'` is identical to bare `claude` for execve;
         //    quoting just removes shell-parsing surprises elsewhere.
+        //    spawn must NOT materialize the user's config.toml — that's
+        //    the job of `atm setup`. (beads agent-tmux-manager-6fb)
         assert_eq!(build_spawn_command(None, None), "'claude'");
-        assert!(config_dir.path().join("atm/config.toml").exists());
+        assert!(
+            !config_dir.path().join("atm/config.toml").exists(),
+            "spawn must not create atm/config.toml as a side effect"
+        );
 
         // 2. Empty value is treated as unset.
         bin.set("");


### PR DESCRIPTION
## Summary
- Move `~/.config/atm/config.toml` materialization out of `atm spawn`
- Make `atm setup` the only command that creates the default config file
- Preserve existing config files on repeated setup runs
- Keep `atm spawn` usable without setup by silently falling back to built-in defaults when config is absent

## Why
`atm spawn` should launch an agent, not mutate XDG config directories. `atm setup` is the explicit environment setup command, so it should own writing the starter config template.

## Verification
- `cargo test --bin atm`
- `cargo test -p atm-tui`
- `cargo build --workspace`
- `cargo clippy --bin atm --tests -- -D warnings`
- `cargo clippy -p atm-tui --tests -- -D warnings`
- Manual probe: isolated `XDG_CONFIG_HOME`, `atm spawn` outside tmux bails on tmux requirement without creating config.toml
- Manual probe: isolated `XDG_CONFIG_HOME`, `atm setup` creates config.toml on first run and preserves user edits on second run

Closes agent-tmux-manager-6fb.