### PR TITLE
refactor: route workspace tmux commands through client

### DIFF
--- a/crates/atm-tmux/src/client.rs
+++ b/crates/atm-tmux/src/client.rs
@@ -97,6 +97,10 @@ impl RealTmuxClient {
 
 #[async_trait]
 impl TmuxClient for RealTmuxClient {
+    async fn raw_command(&self, subcommand: &str, args: &[&str]) -> Result<String, TmuxError> {
+        self.run(subcommand, args).await
+    }
+
     async fn split_window(
         &self,
         target: &str,

--- a/crates/atm-tmux/src/lib.rs
+++ b/crates/atm-tmux/src/lib.rs
@@ -62,6 +62,12 @@ pub struct PaneInfo {
 /// calls for test assertions.
 #[async_trait]
 pub trait TmuxClient: Send + Sync {
+    /// Runs a tmux subcommand and returns stdout.
+    ///
+    /// This is the common escape hatch for commands that do not yet deserve
+    /// a dedicated trait method. Prefer typed methods for shared workflows.
+    async fn raw_command(&self, subcommand: &str, args: &[&str]) -> Result<String, TmuxError>;
+
     /// Splits a pane, returning the new pane ID (e.g., "%7").
     ///
     /// # Arguments

--- a/crates/atm-tmux/src/mock.rs
+++ b/crates/atm-tmux/src/mock.rs
@@ -2,6 +2,7 @@
 //!
 //! Records all method calls and returns configurable results.
 
+use std::collections::{HashMap, VecDeque};
 use std::sync::{Arc, Mutex};
 
 use async_trait::async_trait;
@@ -94,9 +95,11 @@ struct MockState {
     /// Panes returned by list_panes.
     panes: Vec<PaneInfo>,
     /// Content returned by capture_pane, keyed by pane ID.
-    pane_content: std::collections::HashMap<String, Vec<String>>,
+    pane_content: HashMap<String, Vec<String>>,
     /// Working directory returned by get_pane_cwd, keyed by pane ID.
-    pane_cwd: std::collections::HashMap<String, String>,
+    pane_cwd: HashMap<String, String>,
+    /// Queue of stdout strings returned by raw_command.
+    raw_command_outputs: VecDeque<String>,
     /// If set, the next call will return this error.
     next_error: Option<TmuxError>,
 }
@@ -109,8 +112,9 @@ impl MockTmuxClient {
                 calls: Vec::new(),
                 pane_id_queue: Vec::new(),
                 panes: Vec::new(),
-                pane_content: std::collections::HashMap::new(),
-                pane_cwd: std::collections::HashMap::new(),
+                pane_content: HashMap::new(),
+                pane_cwd: HashMap::new(),
+                raw_command_outputs: VecDeque::new(),
                 next_error: None,
             })),
         }
@@ -141,6 +145,13 @@ impl MockTmuxClient {
     pub fn set_pane_cwd(&self, pane: &str, cwd: &str) {
         if let Ok(mut state) = self.inner.lock() {
             state.pane_cwd.insert(pane.to_string(), cwd.to_string());
+        }
+    }
+
+    /// Queues stdout to be returned by the next `raw_command` call.
+    pub fn set_next_raw_output(&self, output: &str) {
+        if let Ok(mut state) = self.inner.lock() {
+            state.raw_command_outputs.push_back(output.to_string());
         }
     }
 
@@ -199,6 +210,15 @@ impl MockTmuxClient {
             })
             .unwrap_or_else(|| "%99".to_string())
     }
+
+    /// Pops the next raw command output, defaulting to an empty string.
+    fn next_raw_output(&self) -> String {
+        self.inner
+            .lock()
+            .ok()
+            .and_then(|mut state| state.raw_command_outputs.pop_front())
+            .unwrap_or_default()
+    }
 }
 
 impl Default for MockTmuxClient {
@@ -210,11 +230,12 @@ impl Default for MockTmuxClient {
 #[async_trait]
 impl TmuxClient for MockTmuxClient {
     async fn raw_command(&self, subcommand: &str, args: &[&str]) -> Result<String, TmuxError> {
+        let output = self.next_raw_output();
         self.record(MockCall::RawCommand {
             subcommand: subcommand.to_string(),
             args: args.iter().map(|arg| (*arg).to_string()).collect(),
         })?;
-        Ok(String::new())
+        Ok(output)
     }
 
     async fn split_window(
@@ -393,6 +414,37 @@ mod tests {
         assert_eq!(p1, "%10");
         assert_eq!(p2, "%11");
         assert_eq!(p3, "%99"); // exhausted queue
+    }
+
+    #[tokio::test]
+    async fn test_mock_raw_command_output_queue() {
+        let mock = MockTmuxClient::new();
+        mock.set_next_raw_output("%1\n%2\n");
+        mock.set_next_raw_output("second");
+
+        let first = mock
+            .raw_command("list-panes", &["-F", "#{pane_id}"])
+            .await
+            .unwrap();
+        let second = mock
+            .raw_command("display-message", &["-p", "x"])
+            .await
+            .unwrap();
+        let third = mock
+            .raw_command("display-message", &["-p", "y"])
+            .await
+            .unwrap();
+
+        assert_eq!(first, "%1\n%2\n");
+        assert_eq!(second, "second");
+        assert_eq!(third, "");
+
+        let calls = mock.calls();
+        assert!(matches!(
+            &calls[0],
+            MockCall::RawCommand { subcommand, args }
+                if subcommand == "list-panes" && args == &vec!["-F".to_string(), "#{pane_id}".to_string()]
+        ));
     }
 
     #[tokio::test]

--- a/crates/atm-tmux/src/mock.rs
+++ b/crates/atm-tmux/src/mock.rs
@@ -11,6 +11,10 @@ use crate::{PaneDirection, PaneInfo, TmuxClient, TmuxError};
 /// A recorded call to the mock tmux client.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum MockCall {
+    RawCommand {
+        subcommand: String,
+        args: Vec<String>,
+    },
     SplitWindow {
         target: String,
         size: String,
@@ -205,6 +209,14 @@ impl Default for MockTmuxClient {
 
 #[async_trait]
 impl TmuxClient for MockTmuxClient {
+    async fn raw_command(&self, subcommand: &str, args: &[&str]) -> Result<String, TmuxError> {
+        self.record(MockCall::RawCommand {
+            subcommand: subcommand.to_string(),
+            args: args.iter().map(|arg| (*arg).to_string()).collect(),
+        })?;
+        Ok(String::new())
+    }
+
     async fn split_window(
         &self,
         target: &str,

--- a/src/bin/atm.rs
+++ b/src/bin/atm.rs
@@ -794,6 +794,14 @@ fn shell_quote(s: &str) -> String {
     format!("'{}'", s.replace('\'', "'\\''"))
 }
 
+/// Builds a shell-safe `tmux` command prefix for generated hook scripts.
+fn tmux_shell_prefix(socket: Option<String>) -> String {
+    match socket {
+        Some(s) => format!("tmux -L {}", shell_quote(&s)),
+        None => "tmux".to_string(),
+    }
+}
+
 /// Build the shell command string sent to a freshly-split tmux pane.
 ///
 /// Honors spawn override environment variables (all treat empty as unset):
@@ -1557,11 +1565,7 @@ async fn install_resize_hooks<C>(
 where
     C: TmuxClient + ?Sized,
 {
-    let effective_socket = effective_tmux_socket(socket);
-    let tmux_prefix = match effective_socket {
-        Some(s) => format!("tmux -L {s}"),
-        None => "tmux".to_string(),
-    };
+    let tmux_prefix = tmux_shell_prefix(effective_tmux_socket(socket));
     let script_dir = dirs::data_local_dir()
         .unwrap_or_else(|| std::path::PathBuf::from("/tmp"))
         .join("atm");
@@ -1663,11 +1667,7 @@ async fn install_new_window_hook<C>(
 where
     C: TmuxClient + ?Sized,
 {
-    let effective_socket = effective_tmux_socket(socket);
-    let tmux_prefix = match effective_socket {
-        Some(s) => format!("tmux -L {s}"),
-        None => "tmux".to_string(),
-    };
+    let tmux_prefix = tmux_shell_prefix(effective_tmux_socket(socket));
     let script_dir = dirs::data_local_dir()
         .unwrap_or_else(|| std::path::PathBuf::from("/tmp"))
         .join("atm");
@@ -2402,6 +2402,24 @@ mod prompt_tests {
         let lines: Vec<String> = vec![];
         let prompt = extract_prompt(&lines);
         assert!(prompt.is_empty());
+    }
+}
+
+#[cfg(test)]
+mod shell_quote_tests {
+    use super::tmux_shell_prefix;
+
+    #[test]
+    fn tmux_shell_prefix_quotes_socket_label() {
+        assert_eq!(tmux_shell_prefix(None), "tmux");
+        assert_eq!(
+            tmux_shell_prefix(Some("sock with spaces".to_string())),
+            "tmux -L 'sock with spaces'"
+        );
+        assert_eq!(
+            tmux_shell_prefix(Some("sock'; touch /tmp/pwned #".to_string())),
+            "tmux -L 'sock'\\''; touch /tmp/pwned #'"
+        );
     }
 }
 

--- a/src/bin/atm.rs
+++ b/src/bin/atm.rs
@@ -1541,19 +1541,35 @@ const SIDEBAR_PCT: u32 = 16;
 const SIDEBAR_MIN: u32 = 20;
 const SIDEBAR_MAX: u32 = 40;
 
-/// Run a tmux command with optional socket, return stdout.
-fn tmux_run(socket: &Option<String>, args: &[&str]) -> Result<String> {
-    let mut cmd = std::process::Command::new("tmux");
-    if let Some(ref s) = socket {
-        cmd.arg("-L").arg(s);
-    }
-    cmd.args(args);
-    let output = cmd.output().context("Failed to run tmux")?;
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        bail!("tmux {:?} failed: {}", args, stderr.trim());
-    }
-    Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+/// Resolves the tmux socket label used by workspace helpers.
+fn effective_tmux_socket(socket: &Option<String>) -> Option<String> {
+    socket.clone().or_else(|| {
+        std::env::var(atm_tmux::client::TMUX_SOCKET_ENV)
+            .ok()
+            .filter(|s| !s.is_empty())
+    })
+}
+
+/// Builds a tmux client for workspace orchestration.
+fn workspace_tmux_client(socket: &Option<String>) -> RealTmuxClient {
+    effective_tmux_socket(socket)
+        .map(RealTmuxClient::with_socket)
+        .unwrap_or_default()
+}
+
+/// Run a tmux command through the shared client abstraction, returning trimmed stdout.
+async fn tmux_run<C>(client: &C, args: &[&str]) -> Result<String>
+where
+    C: TmuxClient + ?Sized,
+{
+    let Some((subcommand, rest)) = args.split_first() else {
+        bail!("tmux command missing subcommand");
+    };
+    let output = client
+        .raw_command(subcommand, rest)
+        .await
+        .with_context(|| format!("tmux {:?} failed", args))?;
+    Ok(output.trim().to_string())
 }
 
 /// Calculate sidebar width from terminal columns, clamped to [SIDEBAR_MIN, SIDEBAR_MAX].
@@ -1581,8 +1597,16 @@ fn default_session_name() -> String {
 }
 
 /// Write the resize-sidebar script and install the after-resize-window hook + prefix keybindings.
-fn install_resize_hooks(socket: &Option<String>, session_name: &str) -> Result<()> {
-    let tmux_prefix = match socket {
+async fn install_resize_hooks<C>(
+    client: &C,
+    socket: &Option<String>,
+    session_name: &str,
+) -> Result<()>
+where
+    C: TmuxClient + ?Sized,
+{
+    let effective_socket = effective_tmux_socket(socket);
+    let tmux_prefix = match effective_socket {
         Some(s) => format!("tmux -L {s}"),
         None => "tmux".to_string(),
     };
@@ -1615,7 +1639,7 @@ fn install_resize_hooks(socket: &Option<String>, session_name: &str) -> Result<(
     }
     let hook_cmd = format!("run-shell '{}'", script_path.display());
     tmux_run(
-        socket,
+        client,
         &[
             "set-hook",
             "-t",
@@ -1623,26 +1647,31 @@ fn install_resize_hooks(socket: &Option<String>, session_name: &str) -> Result<(
             "after-resize-window",
             &hook_cmd,
         ],
-    )?;
+    )
+    .await?;
     // NOTE: bind-key is global; the last workspace created wins for prefix-R.
-    tmux_run(socket, &["bind-key", "-T", "prefix", "R", &hook_cmd])?;
+    tmux_run(client, &["bind-key", "-T", "prefix", "R", &hook_cmd]).await?;
     tmux_run(
-        socket,
+        client,
         &["bind-key", "-T", "prefix", "a", "select-pane", "-t", "0"],
-    )?;
+    )
+    .await?;
     Ok(())
 }
 
 /// Inject an ATM sidebar into a target pane. Returns the sidebar pane ID.
-fn inject_sidebar(
-    socket: &Option<String>,
+async fn inject_sidebar<C>(
+    client: &C,
     target_pane: &str,
     session_name: &str,
     cols: u16,
-) -> Result<String> {
+) -> Result<String>
+where
+    C: TmuxClient + ?Sized,
+{
     let width = sidebar_width(cols).to_string();
     let atm_pane = tmux_run(
-        socket,
+        client,
         &[
             "split-window",
             "-hb",
@@ -1654,25 +1683,36 @@ fn inject_sidebar(
             "-F",
             "#{pane_id}",
         ],
-    )?;
+    )
+    .await?;
     // Tag with both a pane title (for resize script) and a user option (for reliable detection).
     // Pane titles can be overwritten by the shell if ATM crashes; @atm-sidebar persists.
     tmux_run(
-        socket,
+        client,
         &["select-pane", "-t", &atm_pane, "-T", "atm-sidebar"],
-    )?;
+    )
+    .await?;
     tmux_run(
-        socket,
+        client,
         &["set-option", "-p", "-t", &atm_pane, "@atm-sidebar", "1"],
-    )?;
+    )
+    .await?;
     let atm_cmd = format!("atm --compact --tmux-session '{session_name}'");
-    tmux_run(socket, &["send-keys", "-t", &atm_pane, &atm_cmd, "Enter"])?;
+    tmux_run(client, &["send-keys", "-t", &atm_pane, &atm_cmd, "Enter"]).await?;
     Ok(atm_pane)
 }
 
 /// Write the inject-sidebar script for the after-new-window hook.
-fn install_new_window_hook(socket: &Option<String>, session_name: &str) -> Result<()> {
-    let tmux_prefix = match socket {
+async fn install_new_window_hook<C>(
+    client: &C,
+    socket: &Option<String>,
+    session_name: &str,
+) -> Result<()>
+where
+    C: TmuxClient + ?Sized,
+{
+    let effective_socket = effective_tmux_socket(socket);
+    let tmux_prefix = match effective_socket {
         Some(s) => format!("tmux -L {s}"),
         None => "tmux".to_string(),
     };
@@ -1709,7 +1749,7 @@ fn install_new_window_hook(socket: &Option<String>, session_name: &str) -> Resul
     }
     let hook_cmd = format!("run-shell '{}'", script_path.display());
     tmux_run(
-        socket,
+        client,
         &[
             "set-hook",
             "-t",
@@ -1717,7 +1757,8 @@ fn install_new_window_hook(socket: &Option<String>, session_name: &str) -> Resul
             "after-new-window",
             &hook_cmd,
         ],
-    )?;
+    )
+    .await?;
     Ok(())
 }
 
@@ -1733,7 +1774,7 @@ fn exec_attach(socket: &Option<String>, session_name: &str) -> Result<()> {
     }
 
     let mut cmd = std::process::Command::new("tmux");
-    if let Some(ref s) = socket {
+    if let Some(s) = effective_tmux_socket(socket) {
         cmd.arg("-L").arg(s);
     }
     cmd.arg("attach-session").arg("-t").arg(session_name);
@@ -1759,7 +1800,7 @@ fn exec_attach(socket: &Option<String>, session_name: &str) -> Result<()> {
 // Workspace Create
 // ============================================================================
 
-fn cmd_workspace(name: Option<String>, isolate: bool, editor: bool) -> Result<()> {
+async fn cmd_workspace(name: Option<String>, isolate: bool, editor: bool) -> Result<()> {
     // 1. Determine session name, sanitized to safe characters
     let session_name = name.unwrap_or_else(default_session_name);
     validate_session_name(&session_name)?;
@@ -1770,9 +1811,10 @@ fn cmd_workspace(name: Option<String>, isolate: bool, editor: bool) -> Result<()
     } else {
         None
     };
+    let client = workspace_tmux_client(&socket_name);
 
     // 3. Check if session already exists
-    let has_session = tmux_run(&socket_name, &["has-session", "-t", &session_name]);
+    let has_session = tmux_run(&client, &["has-session", "-t", &session_name]).await;
     if has_session.is_ok() {
         if isolate {
             bail!(
@@ -1798,7 +1840,7 @@ fn cmd_workspace(name: Option<String>, isolate: bool, editor: bool) -> Result<()
     let cols_str = cols.to_string();
     let rows_str = rows.to_string();
     let agent_pane = tmux_run(
-        &socket_name,
+        &client,
         &[
             "new-session",
             "-d",
@@ -1812,14 +1854,15 @@ fn cmd_workspace(name: Option<String>, isolate: bool, editor: bool) -> Result<()
             "-F",
             "#{pane_id}",
         ],
-    )?;
+    )
+    .await?;
 
     // 5. Inject ATM sidebar on the left
-    inject_sidebar(&socket_name, &agent_pane, &session_name, cols)?;
+    inject_sidebar(&client, &agent_pane, &session_name, cols).await?;
 
     // 6. Split: shell below the agent pane (20% height)
     tmux_run(
-        &socket_name,
+        &client,
         &[
             "split-window",
             "-v",
@@ -1831,12 +1874,13 @@ fn cmd_workspace(name: Option<String>, isolate: bool, editor: bool) -> Result<()
             "-F",
             "#{pane_id}",
         ],
-    )?;
+    )
+    .await?;
 
     // 7. If --editor: split agent pane horizontally, editor on the left
     if editor {
         tmux_run(
-            &socket_name,
+            &client,
             &[
                 "split-window",
                 "-hb",
@@ -1848,21 +1892,23 @@ fn cmd_workspace(name: Option<String>, isolate: bool, editor: bool) -> Result<()
                 "-F",
                 "#{pane_id}",
             ],
-        )?;
+        )
+        .await?;
     }
 
     // 8. Launch claude in agent pane
     tmux_run(
-        &socket_name,
+        &client,
         &["send-keys", "-t", &agent_pane, "claude", "Enter"],
-    )?;
+    )
+    .await?;
 
     // 9. Install resize/new-window hooks + keybindings
-    install_resize_hooks(&socket_name, &session_name)?;
-    install_new_window_hook(&socket_name, &session_name)?;
+    install_resize_hooks(&client, &socket_name, &session_name).await?;
+    install_new_window_hook(&client, &socket_name, &session_name).await?;
 
     // 10. Focus the agent pane and attach
-    tmux_run(&socket_name, &["select-pane", "-t", &agent_pane])?;
+    tmux_run(&client, &["select-pane", "-t", &agent_pane]).await?;
     exec_attach(&socket_name, &session_name)
 }
 
@@ -1870,7 +1916,7 @@ fn cmd_workspace(name: Option<String>, isolate: bool, editor: bool) -> Result<()
 // Workspace Attach
 // ============================================================================
 
-fn cmd_workspace_attach(session: Option<String>, isolate: bool) -> Result<()> {
+async fn cmd_workspace_attach(session: Option<String>, isolate: bool) -> Result<()> {
     // 1. Resolve target session
     let (session_name, socket_name) = if let Some(name) = session {
         validate_session_name(&name)?;
@@ -1892,13 +1938,14 @@ fn cmd_workspace_attach(session: Option<String>, isolate: bool) -> Result<()> {
             None
         };
         let output = tmux_run(
-            &socket,
+            &workspace_tmux_client(&socket),
             &[
                 "list-sessions",
                 "-F",
                 "#{session_last_attached} #{session_name}",
             ],
-        )?;
+        )
+        .await?;
         let mut sessions: Vec<_> = output
             .lines()
             .filter_map(|line| {
@@ -1916,9 +1963,13 @@ fn cmd_workspace_attach(session: Option<String>, isolate: bool) -> Result<()> {
             .ok_or_else(|| anyhow::anyhow!("No tmux sessions found"))?;
         (session_name, socket)
     };
+    let client = workspace_tmux_client(&socket_name);
 
     // 2. Verify session exists
-    if tmux_run(&socket_name, &["has-session", "-t", &session_name]).is_err() {
+    if tmux_run(&client, &["has-session", "-t", &session_name])
+        .await
+        .is_err()
+    {
         if let Some(ref s) = socket_name {
             bail!("Session '{}' not found on socket '{}'", session_name, s);
         } else {
@@ -1928,7 +1979,7 @@ fn cmd_workspace_attach(session: Option<String>, isolate: bool) -> Result<()> {
 
     // 3. List all windows and their panes, inject sidebar where needed
     let windows_output = tmux_run(
-        &socket_name,
+        &client,
         &[
             "list-windows",
             "-t",
@@ -1936,7 +1987,8 @@ fn cmd_workspace_attach(session: Option<String>, isolate: bool) -> Result<()> {
             "-F",
             "#{window_id} #{window_width}",
         ],
-    )?;
+    )
+    .await?;
 
     for line in windows_output.lines() {
         let mut parts = line.splitn(2, ' ');
@@ -1945,7 +1997,7 @@ fn cmd_workspace_attach(session: Option<String>, isolate: bool) -> Result<()> {
         // Check if this window already has an atm-sidebar pane (using @atm-sidebar option,
         // which survives ATM crashes unlike pane titles that the shell can overwrite)
         let panes_output = tmux_run(
-            &socket_name,
+            &client,
             &[
                 "list-panes",
                 "-t",
@@ -1953,7 +2005,8 @@ fn cmd_workspace_attach(session: Option<String>, isolate: bool) -> Result<()> {
                 "-F",
                 "#{pane_id}:#{@atm-sidebar}",
             ],
-        )?;
+        )
+        .await?;
 
         let has_sidebar = panes_output.lines().any(|line| line.ends_with(":1"));
         if has_sidebar {
@@ -1967,17 +2020,19 @@ fn cmd_workspace_attach(session: Option<String>, isolate: bool) -> Result<()> {
             .and_then(|line| line.split(':').next())
             .ok_or_else(|| anyhow::anyhow!("Window {} has no panes", window_id))?;
 
-        inject_sidebar(&socket_name, first_pane, &session_name, cols).with_context(|| {
-            format!(
-                "Failed to inject sidebar into window {window_id}; \
-                 re-run `atm workspace attach` to complete injection"
-            )
-        })?;
+        inject_sidebar(&client, first_pane, &session_name, cols)
+            .await
+            .with_context(|| {
+                format!(
+                    "Failed to inject sidebar into window {window_id}; \
+                     re-run `atm workspace attach` to complete injection"
+                )
+            })?;
     }
 
     // 5. Install hooks for resize and new windows
-    install_resize_hooks(&socket_name, &session_name)?;
-    install_new_window_hook(&socket_name, &session_name)?;
+    install_resize_hooks(&client, &socket_name, &session_name).await?;
+    install_new_window_hook(&client, &socket_name, &session_name).await?;
 
     // 6. Run the resize script once to correct sidebar widths before attaching
     let script_path = dirs::data_local_dir()
@@ -1985,9 +2040,10 @@ fn cmd_workspace_attach(session: Option<String>, isolate: bool) -> Result<()> {
         .join("atm")
         .join(format!("resize-sidebar-{session_name}.sh"));
     let _ = tmux_run(
-        &socket_name,
+        &client,
         &["run-shell", &format!("{}", script_path.display())],
-    );
+    )
+    .await;
 
     // 7. Attach
     exec_attach(&socket_name, &session_name)
@@ -2093,9 +2149,9 @@ async fn main() -> Result<()> {
                     name,
                     isolate,
                     editor,
-                } => cmd_workspace(name, isolate, editor),
+                } => cmd_workspace(name, isolate, editor).await,
                 WorkspaceAction::Attach { session, isolate } => {
-                    cmd_workspace_attach(session, isolate)
+                    cmd_workspace_attach(session, isolate).await
                 }
             };
         }


### PR DESCRIPTION
## Summary
- add a raw tmux command escape hatch to TmuxClient and MockTmuxClient
- route workspace create/attach tmux calls through RealTmuxClient
- keep attach setup behavior intact while using consistent tmux socket resolution

## Verification
- cargo check --workspace
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace