### PR TITLE
feat: add Devin CLI and GitHub Copilot CLI harness adapters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -138,6 +138,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "atm-copilot-adapter"
+version = "0.2.3"
+dependencies = [
+ "atm-core",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "atm-core"
 version = "0.2.3"
 dependencies = [
@@ -149,6 +158,15 @@ dependencies = [
  "thiserror",
  "tokio",
  "tracing",
+]
+
+[[package]]
+name = "atm-devin-adapter"
+version = "0.2.3"
+dependencies = [
+ "atm-core",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -216,7 +234,9 @@ version = "0.2.3"
 dependencies = [
  "anyhow",
  "atm-claude-adapter",
+ "atm-copilot-adapter",
  "atm-core",
+ "atm-devin-adapter",
  "atm-pi-adapter",
  "atm-protocol",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,8 @@ members = [
     "crates/atm-tmux",
     "crates/atm-claude-adapter",
     "crates/atm-pi-adapter",
+    "crates/atm-devin-adapter",
+    "crates/atm-copilot-adapter",
     "crates/atmd",
     "crates/atm",
 ]
@@ -84,6 +86,8 @@ atm-protocol = { version = "0.2.3", path = "crates/atm-protocol" }
 atm-tmux = { version = "0.2.3", path = "crates/atm-tmux" }
 atm-claude-adapter = { version = "0.2.3", path = "crates/atm-claude-adapter" }
 atm-pi-adapter = { version = "0.2.3", path = "crates/atm-pi-adapter" }
+atm-devin-adapter = { version = "0.2.3", path = "crates/atm-devin-adapter" }
+atm-copilot-adapter = { version = "0.2.3", path = "crates/atm-copilot-adapter" }
 atm-tui = { version = "0.2.3", path = "crates/atm" }
 atmd = { version = "0.2.3", path = "crates/atmd" }
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Real-time management for coding agents across tmux sessions.
 
 ## What it does
 
-ATM gives you a live dashboard and CLI for coding agents running in tmux, including Claude Code and pi. See context usage, cost, model, and activity at a glance — and control agents without switching panes.
+ATM gives you a live dashboard and CLI for coding agents running in tmux, including Claude Code, pi, Devin CLI, and GitHub Copilot CLI. See context usage, cost, model, and activity at a glance — and control agents without switching panes.
 
 - **Dashboard** — real-time TUI with session tree, context bars, cost tracking, and live terminal capture
 - **Agent control** — spawn, kill, interrupt, send text, and reply to prompts from the CLI
@@ -40,6 +40,8 @@ Sessions appear as you use supported coding-agent harnesses. Press `Enter` to ju
 ```bash
 atm spawn -m opus -d right         # spawn default harness with model and direction
 atm spawn --harness pi             # spawn a specific harness
+atm spawn --harness devin          # spawn Devin CLI
+atm spawn --harness copilot        # spawn GitHub Copilot CLI
 ATM_SPAWN_PI_BIN=mise ATM_SPAWN_PI_ARGS='x pi' atm spawn --harness pi
 ```
 
@@ -73,10 +75,10 @@ atm layout pair                    # two agents + ATM sidebar
 ## How it works
 
 ```
-Claude Code / pi  ──hook/extension──▶  atmd (daemon)  ◀──socket──  atm (TUI/CLI)
+Claude Code / pi / Devin CLI / Copilot CLI  ──hook/extension──▶  atmd (daemon)  ◀──socket──  atm (TUI/CLI)
 ```
 
-`atm setup` registers supported harness integrations (Claude Code hooks and the pi extension). Harness events are forwarded to the `atmd` daemon over a Unix socket, and `atm` connects for real-time display.
+`atm setup` registers supported harness integrations (Claude Code hooks, the pi extension, Devin CLI hooks, and Copilot CLI hooks). Harness events are forwarded to the `atmd` daemon over a Unix socket, and `atm` connects for real-time display.
 
 ## Documentation
 

--- a/crates/atm-copilot-adapter/Cargo.toml
+++ b/crates/atm-copilot-adapter/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "atm-copilot-adapter"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+authors.workspace = true
+keywords.workspace = true
+categories.workspace = true
+description = "GitHub Copilot CLI adapter for ATM — translates Copilot CLI raw hook events into vendor-neutral LifecycleEvent"
+
+[dependencies]
+atm-core = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }

--- a/crates/atm-copilot-adapter/src/event.rs
+++ b/crates/atm-copilot-adapter/src/event.rs
@@ -1,0 +1,105 @@
+//! Hook event types from GitHub Copilot CLI.
+//!
+//! `CopilotEventType` is the Copilot-specific raw event vocabulary.
+//! The daemon never matches on it directly —
+//! `RawCopilotHookEvent::to_lifecycle_event()` translates it into a
+//! vendor-neutral `LifecycleEvent` at the connection boundary.
+//!
+//! Unlike Claude Code and Devin CLI (`PascalCase`, snake_case fields),
+//! Copilot CLI's hook configuration keys and event data use
+//! `camelCase` (see
+//! <https://docs.github.com/en/copilot/reference/hooks-reference>).
+
+use serde::{Deserialize, Serialize};
+use std::fmt;
+
+/// All `CopilotEventType` variants paired with their wire string names
+/// (the hook config's event key, e.g. `"preToolUse"`).
+const HOOK_EVENT_VARIANTS: &[(CopilotEventType, &str)] = &[
+    (CopilotEventType::PreToolUse, "preToolUse"),
+    (CopilotEventType::PostToolUse, "postToolUse"),
+    (CopilotEventType::PostToolUseFailure, "postToolUseFailure"),
+    (CopilotEventType::PermissionRequest, "permissionRequest"),
+    (CopilotEventType::UserPromptSubmitted, "userPromptSubmitted"),
+    (CopilotEventType::SessionStart, "sessionStart"),
+    (CopilotEventType::SessionEnd, "sessionEnd"),
+];
+
+/// Types of hook events from GitHub Copilot CLI.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum CopilotEventType {
+    // === Tool Execution ===
+    /// Before a tool executes.
+    PreToolUse,
+    /// After a tool executes successfully.
+    PostToolUse,
+    /// After a tool execution whose result was a failure.
+    PostToolUseFailure,
+
+    // === Permissions ===
+    /// A permission decision is needed for a tool call.
+    PermissionRequest,
+
+    // === User Interaction ===
+    /// User submitted a message.
+    UserPromptSubmitted,
+
+    // === Session Lifecycle ===
+    /// Session begins.
+    SessionStart,
+    /// Session ends.
+    SessionEnd,
+}
+
+impl CopilotEventType {
+    /// Returns the canonical wire-string name (hook config event key)
+    /// for this event type.
+    #[must_use]
+    pub fn as_str(&self) -> &'static str {
+        for (variant, name) in HOOK_EVENT_VARIANTS {
+            if variant == self {
+                return name;
+            }
+        }
+        "unknown"
+    }
+
+    /// Parses from a hook event name string (the hook config's event
+    /// key, e.g. `"preToolUse"`).
+    #[must_use]
+    pub fn from_event_name(name: &str) -> Option<Self> {
+        HOOK_EVENT_VARIANTS
+            .iter()
+            .find(|(_, s)| *s == name)
+            .map(|(v, _)| *v)
+    }
+}
+
+impl fmt::Display for CopilotEventType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_hook_event_all_variants_parse() {
+        for (variant, name) in HOOK_EVENT_VARIANTS {
+            assert_eq!(CopilotEventType::from_event_name(name), Some(*variant));
+        }
+        assert_eq!(CopilotEventType::from_event_name("notARealEvent"), None);
+    }
+
+    #[test]
+    fn test_display_matches_as_str() {
+        assert_eq!(CopilotEventType::PreToolUse.to_string(), "preToolUse");
+        assert_eq!(
+            CopilotEventType::PostToolUseFailure.to_string(),
+            "postToolUseFailure"
+        );
+    }
+}

--- a/crates/atm-copilot-adapter/src/lib.rs
+++ b/crates/atm-copilot-adapter/src/lib.rs
@@ -1,0 +1,26 @@
+//! GitHub Copilot CLI adapter for ATM.
+//!
+//! All Copilot-specific knowledge — the raw event vocabulary, the
+//! wire payload shape, and the translation into vendor-neutral
+//! `atm_core::LifecycleEvent` — lives in this crate. The daemon
+//! (`atmd`) calls into the adapter at the connection boundary; nothing
+//! in `atm-core` or `atm-protocol` references Copilot CLI.
+//!
+//! See <https://docs.github.com/en/copilot/reference/hooks-reference>
+//! for Copilot CLI's hook system. Unlike Claude Code and Devin CLI,
+//! Copilot's hook configuration and event payloads use `camelCase`.
+//!
+//! ## Layers
+//!
+//! - [`event`] — `CopilotEventType` enum (the hook event names)
+//! - [`wire`] — `RawCopilotHookEvent` struct (deserialized JSON
+//!   Copilot sends on stdin to the hook script, plus fields injected
+//!   by `atm-copilot-hook`)
+//! - [`translate`] — translation from raw event to `LifecycleEvent`
+
+pub mod event;
+pub mod translate;
+pub mod wire;
+
+pub use event::CopilotEventType;
+pub use wire::RawCopilotHookEvent;

--- a/crates/atm-copilot-adapter/src/translate.rs
+++ b/crates/atm-copilot-adapter/src/translate.rs
@@ -1,0 +1,209 @@
+//! Translation from Copilot CLI's raw `RawCopilotHookEvent` to
+//! vendor-neutral `LifecycleEvent`.
+//!
+//! This is the *only* place Copilot CLI semantics get mapped to
+//! `atm-core` types. The daemon calls this at the connection boundary
+//! and everything downstream sees only `LifecycleEvent`.
+//!
+//! Copilot's documented hook set doesn't include a per-turn "stop"
+//! event (unlike Claude's `Stop` / Devin's `Stop`), so this adapter
+//! does not emit `LifecycleEvent::WorkingEnd` — sessions rely on
+//! `SessionEnd` for the "no longer active" signal. Revisit if GitHub
+//! documents an equivalent (their docs reference an "agent stop"
+//! lifecycle point without giving its `hooks.json` event key).
+
+use atm_core::{LifecycleEvent, NeedsInputReason, NotificationKind, Tool};
+
+use crate::event::CopilotEventType;
+use crate::wire::RawCopilotHookEvent;
+
+impl RawCopilotHookEvent {
+    /// Translates this Copilot CLI raw event into a vendor-neutral
+    /// `LifecycleEvent`.
+    ///
+    /// Returns `None` if `hook_event_name` does not match a known
+    /// Copilot event, or if a tool-shaped event is missing
+    /// `tool_name` (malformed — mirrors the other adapters' guard
+    /// against fabricating phantom tool-call records).
+    pub fn to_lifecycle_event(&self) -> Option<LifecycleEvent> {
+        let ev = self.event_type()?;
+        let needs_tool = matches!(
+            ev,
+            CopilotEventType::PreToolUse
+                | CopilotEventType::PostToolUse
+                | CopilotEventType::PostToolUseFailure
+        );
+        let tool_name = self.tool_name.as_deref().unwrap_or("");
+        if needs_tool && tool_name.is_empty() {
+            return None;
+        }
+        // Copilot's tool-name vocabulary isn't well-documented publicly
+        // and its casing doesn't match Claude's, so — unlike
+        // `atm-devin-adapter` — no vendor-specific normalization table
+        // is asserted here. Unknown names land in `Tool::Other`, which
+        // still round-trips the original name for display.
+        let tool = Tool::from(tool_name);
+        Some(match ev {
+            CopilotEventType::PreToolUse => {
+                if tool.is_interactive() {
+                    LifecycleEvent::NeedsInput {
+                        reason: NeedsInputReason::InteractiveTool { tool },
+                    }
+                } else {
+                    LifecycleEvent::ToolCallStart {
+                        name: tool,
+                        tool_use_id: None,
+                        input: self.tool_args.clone(),
+                    }
+                }
+            }
+            CopilotEventType::PostToolUse => LifecycleEvent::ToolCallEnd {
+                name: tool,
+                tool_use_id: None,
+                is_error: false,
+            },
+            CopilotEventType::PostToolUseFailure => LifecycleEvent::ToolCallEnd {
+                name: tool,
+                tool_use_id: None,
+                is_error: true,
+            },
+            CopilotEventType::PermissionRequest => LifecycleEvent::NeedsInput {
+                reason: NeedsInputReason::Notification {
+                    kind: NotificationKind::PermissionPrompt,
+                    label: self.tool_name.clone(),
+                },
+            },
+            CopilotEventType::UserPromptSubmitted => LifecycleEvent::PromptSubmit {
+                prompt: self.prompt.clone(),
+            },
+            CopilotEventType::SessionStart => LifecycleEvent::SessionStart {
+                source: self.source.clone(),
+            },
+            CopilotEventType::SessionEnd => LifecycleEvent::SessionEnd {
+                reason: self.reason.clone(),
+            },
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn raw(name: &str) -> RawCopilotHookEvent {
+        RawCopilotHookEvent {
+            session_id: "s".into(),
+            hook_event_name: name.into(),
+            pid: None,
+            tmux_pane: None,
+            tool_name: None,
+            tool_args: None,
+            tool_result: None,
+            error: None,
+            prompt: None,
+            source: None,
+            reason: None,
+        }
+    }
+
+    #[test]
+    fn pre_tool_use_carries_args() {
+        let mut e = raw("preToolUse");
+        e.tool_name = Some("bash".into());
+        e.tool_args = Some(serde_json::json!({"command": "ls"}));
+        assert_eq!(
+            e.to_lifecycle_event(),
+            Some(LifecycleEvent::ToolCallStart {
+                name: Tool::Other("bash".into()),
+                tool_use_id: None,
+                input: Some(serde_json::json!({"command": "ls"})),
+            })
+        );
+    }
+
+    #[test]
+    fn tool_shaped_events_without_tool_name_return_none() {
+        for name in ["preToolUse", "postToolUse", "postToolUseFailure"] {
+            assert_eq!(raw(name).to_lifecycle_event(), None);
+        }
+    }
+
+    #[test]
+    fn post_tool_use_and_failure_variant() {
+        let mut ok = raw("postToolUse");
+        ok.tool_name = Some("bash".into());
+        assert_eq!(
+            ok.to_lifecycle_event(),
+            Some(LifecycleEvent::ToolCallEnd {
+                name: Tool::Other("bash".into()),
+                tool_use_id: None,
+                is_error: false,
+            })
+        );
+
+        let mut fail = raw("postToolUseFailure");
+        fail.tool_name = Some("bash".into());
+        fail.error = Some("boom".into());
+        assert_eq!(
+            fail.to_lifecycle_event(),
+            Some(LifecycleEvent::ToolCallEnd {
+                name: Tool::Other("bash".into()),
+                tool_use_id: None,
+                is_error: true,
+            })
+        );
+    }
+
+    #[test]
+    fn permission_request_becomes_needs_input() {
+        let mut e = raw("permissionRequest");
+        e.tool_name = Some("bash".into());
+        assert_eq!(
+            e.to_lifecycle_event(),
+            Some(LifecycleEvent::NeedsInput {
+                reason: NeedsInputReason::Notification {
+                    kind: NotificationKind::PermissionPrompt,
+                    label: Some("bash".into()),
+                }
+            })
+        );
+    }
+
+    #[test]
+    fn user_prompt_submitted_carries_prompt() {
+        let mut e = raw("userPromptSubmitted");
+        e.prompt = Some("fix the tests".into());
+        assert_eq!(
+            e.to_lifecycle_event(),
+            Some(LifecycleEvent::PromptSubmit {
+                prompt: Some("fix the tests".into())
+            })
+        );
+    }
+
+    #[test]
+    fn session_start_and_end_carry_fields() {
+        let mut start = raw("sessionStart");
+        start.source = Some("startup".into());
+        assert_eq!(
+            start.to_lifecycle_event(),
+            Some(LifecycleEvent::SessionStart {
+                source: Some("startup".into())
+            })
+        );
+
+        let mut end = raw("sessionEnd");
+        end.reason = Some("user_exit".into());
+        assert_eq!(
+            end.to_lifecycle_event(),
+            Some(LifecycleEvent::SessionEnd {
+                reason: Some("user_exit".into())
+            })
+        );
+    }
+
+    #[test]
+    fn unknown_event_returns_none() {
+        assert_eq!(raw("notARealEvent").to_lifecycle_event(), None);
+    }
+}

--- a/crates/atm-copilot-adapter/src/translate.rs
+++ b/crates/atm-copilot-adapter/src/translate.rs
@@ -22,9 +22,12 @@ impl RawCopilotHookEvent {
     /// `LifecycleEvent`.
     ///
     /// Returns `None` if `hook_event_name` does not match a known
-    /// Copilot event, or if a tool-shaped event is missing
-    /// `tool_name` (malformed — mirrors the other adapters' guard
-    /// against fabricating phantom tool-call records).
+    /// Copilot event, or if a tool-shaped event (`preToolUse`,
+    /// `postToolUse`, `postToolUseFailure`, `permissionRequest`) is
+    /// missing `tool_name` (malformed — mirrors the other adapters'
+    /// guard against fabricating phantom tool-call records, and keeps
+    /// `permissionRequest` consistent since it also relies on
+    /// `tool_name` for its `NeedsInput` label).
     pub fn to_lifecycle_event(&self) -> Option<LifecycleEvent> {
         let ev = self.event_type()?;
         let needs_tool = matches!(
@@ -32,6 +35,7 @@ impl RawCopilotHookEvent {
             CopilotEventType::PreToolUse
                 | CopilotEventType::PostToolUse
                 | CopilotEventType::PostToolUseFailure
+                | CopilotEventType::PermissionRequest
         );
         let tool_name = self.tool_name.as_deref().unwrap_or("");
         if needs_tool && tool_name.is_empty() {
@@ -123,7 +127,12 @@ mod tests {
 
     #[test]
     fn tool_shaped_events_without_tool_name_return_none() {
-        for name in ["preToolUse", "postToolUse", "postToolUseFailure"] {
+        for name in [
+            "preToolUse",
+            "postToolUse",
+            "postToolUseFailure",
+            "permissionRequest",
+        ] {
             assert_eq!(raw(name).to_lifecycle_event(), None);
         }
     }

--- a/crates/atm-copilot-adapter/src/wire.rs
+++ b/crates/atm-copilot-adapter/src/wire.rs
@@ -1,0 +1,172 @@
+//! Raw GitHub Copilot CLI hook-event payload (the JSON Copilot sends
+//! on stdin to the hook script).
+//!
+//! Copilot's own per-event payloads (see
+//! <https://github.com/github/copilot-sdk/blob/main/rust/src/hooks.rs>
+//! for the authoritative field shapes) don't carry an explicit
+//! "which event is this" field — the event kind is implied by which
+//! array in `hooks.json` the command was registered under. Our
+//! installed hook script (`atm-copilot-hook`, one invocation per
+//! event array) adds a `hookEventName` field before forwarding to
+//! atmd, mirroring how `atm-claude-adapter`'s `hook_event_name` and
+//! `atm-devin-adapter`'s `hook_event_name` work — this keeps a single
+//! envelope shape across all three adapters at the connection
+//! boundary.
+
+use atm_core::SessionId;
+use serde::{Deserialize, Deserializer};
+use serde_json::Value;
+
+use crate::event::CopilotEventType;
+
+/// Raw hook event JSON structure from Copilot CLI (as forwarded by
+/// `atm-copilot-hook`).
+///
+/// Use typed conversion ([`Self::to_lifecycle_event`]) for
+/// domain-layer type safety; the daemon never matches on
+/// `hook_event_name` strings.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RawCopilotHookEvent {
+    // === Common fields (injected by atm-copilot-hook) ===
+    pub session_id: String,
+    pub hook_event_name: String,
+
+    // === Injected by hook script ===
+    #[serde(default)]
+    pub pid: Option<u32>,
+    #[serde(default)]
+    pub tmux_pane: Option<String>,
+
+    // === Tool events (preToolUse, postToolUse, postToolUseFailure) ===
+    #[serde(default)]
+    pub tool_name: Option<String>,
+    /// Arguments passed to the tool.
+    ///
+    /// Documented as an object, but real CLI invocations have been
+    /// observed sending a JSON-encoded *string* instead (see
+    /// <https://github.com/github/copilot-cli/issues/3349>). Accept
+    /// both via a custom deserializer rather than failing the whole
+    /// event on a shape we don't control.
+    #[serde(default, deserialize_with = "deserialize_json_ish")]
+    pub tool_args: Option<Value>,
+    /// Result returned by the tool (`postToolUse` only).
+    #[serde(default, deserialize_with = "deserialize_json_ish")]
+    pub tool_result: Option<Value>,
+    /// Failure message (`postToolUseFailure` only — Copilot extracts
+    /// this from the tool result rather than passing it whole).
+    #[serde(default)]
+    pub error: Option<String>,
+
+    // === User prompt (userPromptSubmitted) ===
+    #[serde(default)]
+    pub prompt: Option<String>,
+
+    // === Session events (sessionStart, sessionEnd) ===
+    #[serde(default)]
+    pub source: Option<String>,
+    #[serde(default)]
+    pub reason: Option<String>,
+}
+
+/// Deserializes a field that should be a JSON object but may arrive
+/// as a JSON-encoded string (see [`RawCopilotHookEvent::tool_args`]).
+fn deserialize_json_ish<'de, D>(deserializer: D) -> Result<Option<Value>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let value = Option::<Value>::deserialize(deserializer)?;
+    Ok(value.map(|v| match v {
+        Value::String(s) => serde_json::from_str(&s).unwrap_or(Value::String(s)),
+        other => other,
+    }))
+}
+
+impl RawCopilotHookEvent {
+    /// Parses the hook event type.
+    pub fn event_type(&self) -> Option<CopilotEventType> {
+        CopilotEventType::from_event_name(&self.hook_event_name)
+    }
+
+    /// Returns the session ID.
+    pub fn session_id(&self) -> SessionId {
+        SessionId::new(&self.session_id)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_pre_tool_use_object_args() {
+        let json = r#"{
+            "sessionId": "s-1",
+            "hookEventName": "preToolUse",
+            "toolName": "bash",
+            "toolArgs": {"command": "ls"}
+        }"#;
+        let event: RawCopilotHookEvent = serde_json::from_str(json).unwrap();
+        assert_eq!(event.event_type(), Some(CopilotEventType::PreToolUse));
+        assert_eq!(event.tool_args, Some(serde_json::json!({"command": "ls"})));
+    }
+
+    #[test]
+    fn parse_pre_tool_use_string_encoded_args() {
+        // Regression for github/copilot-cli#3349: toolArgs observed as
+        // a JSON-encoded string rather than a parsed object.
+        let json = r#"{
+            "sessionId": "s-1",
+            "hookEventName": "preToolUse",
+            "toolName": "bash",
+            "toolArgs": "{\"command\":\"echo hello\"}"
+        }"#;
+        let event: RawCopilotHookEvent = serde_json::from_str(json).unwrap();
+        assert_eq!(
+            event.tool_args,
+            Some(serde_json::json!({"command": "echo hello"}))
+        );
+    }
+
+    #[test]
+    fn parse_post_tool_use_failure() {
+        let json = r#"{
+            "sessionId": "s-1",
+            "hookEventName": "postToolUseFailure",
+            "toolName": "bash",
+            "error": "command not found"
+        }"#;
+        let event: RawCopilotHookEvent = serde_json::from_str(json).unwrap();
+        assert_eq!(
+            event.event_type(),
+            Some(CopilotEventType::PostToolUseFailure)
+        );
+        assert_eq!(event.error.as_deref(), Some("command not found"));
+    }
+
+    #[test]
+    fn parse_user_prompt_submitted() {
+        let json = r#"{
+            "sessionId": "s-1",
+            "hookEventName": "userPromptSubmitted",
+            "prompt": "fix the tests"
+        }"#;
+        let event: RawCopilotHookEvent = serde_json::from_str(json).unwrap();
+        assert_eq!(event.prompt.as_deref(), Some("fix the tests"));
+    }
+
+    #[test]
+    fn parse_session_start_and_end() {
+        let start: RawCopilotHookEvent = serde_json::from_str(
+            r#"{"sessionId":"s-1","hookEventName":"sessionStart","source":"startup"}"#,
+        )
+        .unwrap();
+        assert_eq!(start.source.as_deref(), Some("startup"));
+
+        let end: RawCopilotHookEvent = serde_json::from_str(
+            r#"{"sessionId":"s-1","hookEventName":"sessionEnd","reason":"user_exit"}"#,
+        )
+        .unwrap();
+        assert_eq!(end.reason.as_deref(), Some("user_exit"));
+    }
+}

--- a/crates/atm-core/src/harness.rs
+++ b/crates/atm-core/src/harness.rs
@@ -35,6 +35,10 @@ pub enum Harness {
     Qwen,
     /// Gemini CLI.
     Gemini,
+    /// Devin CLI (<https://devin.ai/>).
+    Devin,
+    /// GitHub Copilot CLI.
+    Copilot,
     /// Unknown harness — discovered via process scanning before any
     /// adapter event arrived, or a future harness we haven't tagged.
     #[default]
@@ -53,6 +57,8 @@ impl Harness {
             Self::Amp => "amp",
             Self::Qwen => "qwen",
             Self::Gemini => "gemini",
+            Self::Devin => "devin",
+            Self::Copilot => "copilot",
             Self::Unknown => "?",
         }
     }
@@ -67,6 +73,8 @@ impl fmt::Display for Harness {
             Self::Amp => "Amp",
             Self::Qwen => "Qwen Code",
             Self::Gemini => "Gemini CLI",
+            Self::Devin => "Devin CLI",
+            Self::Copilot => "GitHub Copilot CLI",
             Self::Unknown => "unknown",
         })
     }
@@ -90,6 +98,11 @@ mod tests {
             serde_json::to_string(&Harness::Gemini).unwrap(),
             "\"gemini\""
         );
+        assert_eq!(serde_json::to_string(&Harness::Devin).unwrap(), "\"devin\"");
+        assert_eq!(
+            serde_json::to_string(&Harness::Copilot).unwrap(),
+            "\"copilot\""
+        );
         assert_eq!(
             serde_json::to_string(&Harness::Unknown).unwrap(),
             "\"unknown\""
@@ -109,6 +122,8 @@ mod tests {
         assert_eq!(Harness::Amp.short_tag(), "amp");
         assert_eq!(Harness::Qwen.short_tag(), "qwen");
         assert_eq!(Harness::Gemini.short_tag(), "gemini");
+        assert_eq!(Harness::Devin.short_tag(), "devin");
+        assert_eq!(Harness::Copilot.short_tag(), "copilot");
         assert_eq!(Harness::Unknown.short_tag(), "?");
     }
 }

--- a/crates/atm-core/src/harness_registry.rs
+++ b/crates/atm-core/src/harness_registry.rs
@@ -111,6 +111,17 @@ const GEMINI_MATCHERS: &[ProcessMatcher] = &[
     ProcessMatcher::Contains("gemini-cli"),
 ];
 
+const DEVIN_MATCHERS: &[ProcessMatcher] = &[
+    ProcessMatcher::Exact("devin"),
+    ProcessMatcher::Suffix("/devin"),
+    ProcessMatcher::Contains("devin/cli/"),
+];
+
+const COPILOT_MATCHERS: &[ProcessMatcher] = &[
+    ProcessMatcher::Exact("copilot"),
+    ProcessMatcher::Suffix("/copilot"),
+];
+
 /// Built-in harness definitions.
 pub const BUILTIN_HARNESSES: &[HarnessDefinition] = &[
     HarnessDefinition {
@@ -195,6 +206,34 @@ pub const BUILTIN_HARNESSES: &[HarnessDefinition] = &[
         version_args: &["--version"],
         process_matchers: GEMINI_MATCHERS,
         discovery_enabled: false,
+        allow_bare_cmdline_match: true,
+    },
+    HarnessDefinition {
+        id: "devin",
+        aliases: &["devin-cli"],
+        display_name: "Devin CLI",
+        harness: Harness::Devin,
+        binary: "devin",
+        default_args: &[],
+        model_flag: Some("--model"),
+        prompt_mode: PromptMode::KeystrokeInjection,
+        version_args: &["version"],
+        process_matchers: DEVIN_MATCHERS,
+        discovery_enabled: true,
+        allow_bare_cmdline_match: true,
+    },
+    HarnessDefinition {
+        id: "copilot",
+        aliases: &["copilot-cli", "gh-copilot"],
+        display_name: "GitHub Copilot CLI",
+        harness: Harness::Copilot,
+        binary: "copilot",
+        default_args: &[],
+        model_flag: Some("--model"),
+        prompt_mode: PromptMode::KeystrokeInjection,
+        version_args: &["--version"],
+        process_matchers: COPILOT_MATCHERS,
+        discovery_enabled: true,
         allow_bare_cmdline_match: true,
     },
 ];

--- a/crates/atm-devin-adapter/Cargo.toml
+++ b/crates/atm-devin-adapter/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "atm-devin-adapter"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+authors.workspace = true
+keywords.workspace = true
+categories.workspace = true
+description = "Devin CLI adapter for ATM — translates Devin CLI raw hook events into vendor-neutral LifecycleEvent"
+
+[dependencies]
+atm-core = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }

--- a/crates/atm-devin-adapter/src/event.rs
+++ b/crates/atm-devin-adapter/src/event.rs
@@ -1,0 +1,115 @@
+//! Hook event types from Devin CLI.
+//!
+//! `DevinEventType` is the Devin-specific raw event vocabulary. The
+//! daemon never matches on it directly — `RawDevinHookEvent::to_lifecycle_event()`
+//! translates it into a vendor-neutral `LifecycleEvent` at the
+//! connection boundary.
+//!
+//! Devin CLI's hook system (see
+//! <https://docs.devin.ai/cli/extensibility/hooks/overview>) is
+//! close to Claude Code's — same JSON-on-stdin shape, same
+//! `session_id` correlation id — but the event vocabulary differs
+//! slightly: Devin has `PermissionRequest` as its own event (Claude
+//! folds permission gating into `PreToolUse`/`Notification`) and
+//! `PostCompaction` instead of `PreCompact`, and has no
+//! `SubagentStart`/`SubagentStop`/`Setup`/`Notification` events.
+
+use serde::{Deserialize, Serialize};
+use std::fmt;
+
+/// All `DevinEventType` variants paired with their string names.
+/// Single source of truth for string conversion.
+const HOOK_EVENT_VARIANTS: &[(DevinEventType, &str)] = &[
+    (DevinEventType::PreToolUse, "PreToolUse"),
+    (DevinEventType::PostToolUse, "PostToolUse"),
+    (DevinEventType::PermissionRequest, "PermissionRequest"),
+    (DevinEventType::UserPromptSubmit, "UserPromptSubmit"),
+    (DevinEventType::Stop, "Stop"),
+    (DevinEventType::PostCompaction, "PostCompaction"),
+    (DevinEventType::SessionStart, "SessionStart"),
+    (DevinEventType::SessionEnd, "SessionEnd"),
+];
+
+/// Types of hook events from Devin CLI.
+///
+/// All 8 documented Devin CLI hook events.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub enum DevinEventType {
+    // === Tool Execution ===
+    /// Before a tool is executed.
+    PreToolUse,
+    /// After a tool finishes (success or failure — Devin does not
+    /// split this into a separate failure event like Claude does).
+    PostToolUse,
+
+    // === Permissions ===
+    /// A permission decision is needed for a tool call.
+    PermissionRequest,
+
+    // === User Interaction ===
+    /// User submitted a prompt.
+    UserPromptSubmit,
+    /// Devin stopped responding (finished its turn).
+    Stop,
+
+    // === Context Management ===
+    /// Context compaction just completed.
+    PostCompaction,
+
+    // === Session Lifecycle ===
+    /// Session started (new, resumed, or startup).
+    SessionStart,
+    /// Session ended.
+    SessionEnd,
+}
+
+impl DevinEventType {
+    /// Returns the canonical string name for this event type.
+    #[must_use]
+    pub fn as_str(&self) -> &'static str {
+        for (variant, name) in HOOK_EVENT_VARIANTS {
+            if variant == self {
+                return name;
+            }
+        }
+        "Unknown"
+    }
+
+    /// Parses from a hook event name string.
+    #[must_use]
+    pub fn from_event_name(name: &str) -> Option<Self> {
+        HOOK_EVENT_VARIANTS
+            .iter()
+            .find(|(_, s)| *s == name)
+            .map(|(v, _)| *v)
+    }
+}
+
+impl fmt::Display for DevinEventType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_hook_event_all_variants_parse() {
+        for (variant, name) in HOOK_EVENT_VARIANTS {
+            assert_eq!(DevinEventType::from_event_name(name), Some(*variant));
+        }
+        assert_eq!(DevinEventType::from_event_name("NotARealEvent"), None);
+    }
+
+    #[test]
+    fn test_display_matches_as_str() {
+        assert_eq!(DevinEventType::PreToolUse.to_string(), "PreToolUse");
+        assert_eq!(
+            DevinEventType::PermissionRequest.to_string(),
+            "PermissionRequest"
+        );
+    }
+}

--- a/crates/atm-devin-adapter/src/lib.rs
+++ b/crates/atm-devin-adapter/src/lib.rs
@@ -1,0 +1,30 @@
+//! Devin CLI adapter for ATM.
+//!
+//! All Devin-specific knowledge — the raw event vocabulary, the wire
+//! payload shape, and the translation into vendor-neutral
+//! `atm_core::LifecycleEvent` — lives in this crate. The daemon
+//! (`atmd`) calls into the adapter at the connection boundary; nothing
+//! in `atm-core` or `atm-protocol` references Devin CLI.
+//!
+//! Devin CLI's hook system
+//! (<https://docs.devin.ai/cli/extensibility/hooks/overview>) is
+//! structurally close to Claude Code's — JSON-on-stdin, a
+//! `session_id` correlation id, the same `command`-hook config
+//! shape — which is why this crate mirrors `atm-claude-adapter`'s
+//! layout closely. The event vocabulary and tool-name casing differ
+//! (Devin uses lowercase/`snake_case` tool names), so it gets its own
+//! adapter rather than reusing Claude's.
+//!
+//! ## Layers
+//!
+//! - [`event`] — `DevinEventType` enum (the 8 Devin CLI hook event names)
+//! - [`wire`] — `RawDevinHookEvent` struct (deserialized JSON Devin
+//!   sends on stdin to the hook script)
+//! - [`translate`] — translation from raw event to `LifecycleEvent`
+
+pub mod event;
+pub mod translate;
+pub mod wire;
+
+pub use event::DevinEventType;
+pub use wire::RawDevinHookEvent;

--- a/crates/atm-devin-adapter/src/translate.rs
+++ b/crates/atm-devin-adapter/src/translate.rs
@@ -47,12 +47,20 @@ impl RawDevinHookEvent {
     /// `LifecycleEvent`.
     ///
     /// Returns `None` if `hook_event_name` does not match a known
-    /// Devin event, or if a tool-shaped event is missing `tool_name`
+    /// Devin event, or if a tool-shaped event (`PreToolUse`,
+    /// `PostToolUse`, `PermissionRequest`) is missing `tool_name`
     /// (malformed — mirrors `atm_claude_adapter`'s guard against
-    /// fabricating phantom tool-call records).
+    /// fabricating phantom tool-call records, and keeps
+    /// `PermissionRequest` consistent since it also relies on
+    /// `tool_name` for its `NeedsInput` label).
     pub fn to_lifecycle_event(&self) -> Option<LifecycleEvent> {
         let ev = self.event_type()?;
-        let needs_tool = matches!(ev, DevinEventType::PreToolUse | DevinEventType::PostToolUse);
+        let needs_tool = matches!(
+            ev,
+            DevinEventType::PreToolUse
+                | DevinEventType::PostToolUse
+                | DevinEventType::PermissionRequest
+        );
         let tool_name = self.tool_name.as_deref().unwrap_or("");
         if needs_tool && tool_name.is_empty() {
             return None;
@@ -170,7 +178,7 @@ mod tests {
 
     #[test]
     fn tool_shaped_event_without_tool_name_returns_none() {
-        for name in ["PreToolUse", "PostToolUse"] {
+        for name in ["PreToolUse", "PostToolUse", "PermissionRequest"] {
             assert_eq!(raw(name).to_lifecycle_event(), None);
             let mut empty = raw(name);
             empty.tool_name = Some(String::new());

--- a/crates/atm-devin-adapter/src/translate.rs
+++ b/crates/atm-devin-adapter/src/translate.rs
@@ -1,0 +1,285 @@
+//! Translation from Devin CLI's raw `RawDevinHookEvent` to
+//! vendor-neutral `LifecycleEvent`.
+//!
+//! This is the *only* place Devin CLI semantics get mapped to
+//! `atm-core` types. The daemon calls this at the connection boundary
+//! and everything downstream sees only `LifecycleEvent`.
+
+use atm_core::{LifecycleEvent, NeedsInputReason, NotificationKind, Tool};
+
+use crate::event::DevinEventType;
+use crate::wire::RawDevinHookEvent;
+
+/// Maps a Devin CLI tool name onto atm-core's `Tool` enum.
+///
+/// Devin's tool names are lowercase/`snake_case` (e.g. `exec`, `edit`,
+/// `todo_write`) rather than Claude's PascalCase (`Bash`, `Edit`,
+/// `TodoWrite`). `Tool::from` only recognizes Claude's exact casing,
+/// so tool-name normalization for a vendor with different casing
+/// lives here rather than in the shared `Tool` type — keeping vendor
+/// knowledge contained to its own adapter crate, per this crate's
+/// stated design.
+///
+/// Devin tool names without a clear Claude-shaped equivalent (e.g.
+/// `apply_patch`, `skill`, `mcp_*`) fall through to `Tool::Other`,
+/// preserving Devin's native name.
+fn normalize_tool_name(name: &str) -> Tool {
+    match name {
+        "read" => Tool::Read,
+        "write" => Tool::Write,
+        "edit" => Tool::Edit,
+        "grep" => Tool::Grep,
+        "glob" => Tool::Glob,
+        "exec" => Tool::Bash,
+        "webfetch" => Tool::WebFetch,
+        "todo_write" => Tool::TodoWrite,
+        "notebook_edit" => Tool::NotebookEdit,
+        "notebook_read" => Tool::NotebookRead,
+        "exit_plan_mode" => Tool::ExitPlanMode,
+        "ask_user_question" => Tool::AskUserQuestion,
+        "run_subagent" => Tool::Task,
+        other => Tool::Other(other.to_string()),
+    }
+}
+
+impl RawDevinHookEvent {
+    /// Translates this Devin CLI raw event into a vendor-neutral
+    /// `LifecycleEvent`.
+    ///
+    /// Returns `None` if `hook_event_name` does not match a known
+    /// Devin event, or if a tool-shaped event is missing `tool_name`
+    /// (malformed — mirrors `atm_claude_adapter`'s guard against
+    /// fabricating phantom tool-call records).
+    pub fn to_lifecycle_event(&self) -> Option<LifecycleEvent> {
+        let ev = self.event_type()?;
+        let needs_tool = matches!(ev, DevinEventType::PreToolUse | DevinEventType::PostToolUse);
+        let tool_name = self.tool_name.as_deref().unwrap_or("");
+        if needs_tool && tool_name.is_empty() {
+            return None;
+        }
+        let tool = normalize_tool_name(tool_name);
+        Some(match ev {
+            DevinEventType::PreToolUse => {
+                if tool.is_interactive() {
+                    LifecycleEvent::NeedsInput {
+                        reason: NeedsInputReason::InteractiveTool { tool },
+                    }
+                } else {
+                    LifecycleEvent::ToolCallStart {
+                        name: tool,
+                        tool_use_id: None,
+                        input: self.tool_input.clone(),
+                    }
+                }
+            }
+            DevinEventType::PostToolUse => LifecycleEvent::ToolCallEnd {
+                name: tool,
+                tool_use_id: None,
+                is_error: self.tool_failed(),
+            },
+            DevinEventType::PermissionRequest => LifecycleEvent::NeedsInput {
+                reason: NeedsInputReason::Notification {
+                    kind: NotificationKind::PermissionPrompt,
+                    label: self.tool_name.clone(),
+                },
+            },
+            DevinEventType::UserPromptSubmit => LifecycleEvent::PromptSubmit {
+                prompt: self.prompt.clone(),
+            },
+            DevinEventType::Stop => LifecycleEvent::WorkingEnd,
+            DevinEventType::PostCompaction => LifecycleEvent::Notification {
+                message: self.summary.clone(),
+                kind: Some(NotificationKind::Info),
+            },
+            DevinEventType::SessionStart => LifecycleEvent::SessionStart {
+                source: self.source.clone(),
+            },
+            DevinEventType::SessionEnd => LifecycleEvent::SessionEnd {
+                reason: self.reason.clone(),
+            },
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn raw(name: &str) -> RawDevinHookEvent {
+        RawDevinHookEvent {
+            session_id: "s".into(),
+            hook_event_name: name.into(),
+            prompt_id: None,
+            pid: None,
+            tmux_pane: None,
+            tool_name: None,
+            tool_input: None,
+            tool_response: None,
+            prompt: None,
+            stop_hook_active: None,
+            summary: None,
+            source: None,
+            reason: None,
+        }
+    }
+
+    #[test]
+    fn pre_tool_use_maps_known_tool_and_carries_input() {
+        let mut e = raw("PreToolUse");
+        e.tool_name = Some("exec".into());
+        e.tool_input = Some(serde_json::json!({"command": "ls"}));
+        assert_eq!(
+            e.to_lifecycle_event(),
+            Some(LifecycleEvent::ToolCallStart {
+                name: Tool::Bash,
+                tool_use_id: None,
+                input: Some(serde_json::json!({"command": "ls"})),
+            })
+        );
+    }
+
+    #[test]
+    fn pre_tool_use_unmapped_tool_lands_in_other() {
+        let mut e = raw("PreToolUse");
+        e.tool_name = Some("mcp__github__list_issues".into());
+        match e.to_lifecycle_event() {
+            Some(LifecycleEvent::ToolCallStart { name, .. }) => {
+                assert_eq!(name, Tool::Other("mcp__github__list_issues".into()));
+            }
+            other => panic!("expected ToolCallStart, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn pre_tool_use_interactive_tools_become_needs_input() {
+        for (name, expected) in [
+            ("exit_plan_mode", Tool::ExitPlanMode),
+            ("ask_user_question", Tool::AskUserQuestion),
+        ] {
+            let mut e = raw("PreToolUse");
+            e.tool_name = Some(name.into());
+            assert_eq!(
+                e.to_lifecycle_event(),
+                Some(LifecycleEvent::NeedsInput {
+                    reason: NeedsInputReason::InteractiveTool { tool: expected }
+                }),
+                "tool {name} should map to NeedsInput"
+            );
+        }
+    }
+
+    #[test]
+    fn tool_shaped_event_without_tool_name_returns_none() {
+        for name in ["PreToolUse", "PostToolUse"] {
+            assert_eq!(raw(name).to_lifecycle_event(), None);
+            let mut empty = raw(name);
+            empty.tool_name = Some(String::new());
+            assert_eq!(empty.to_lifecycle_event(), None);
+        }
+    }
+
+    #[test]
+    fn post_tool_use_distinguishes_failure_via_tool_response() {
+        let mut ok = raw("PostToolUse");
+        ok.tool_name = Some("exec".into());
+        ok.tool_response = Some(serde_json::json!({"success": true, "output": "", "error": null}));
+        assert_eq!(
+            ok.to_lifecycle_event(),
+            Some(LifecycleEvent::ToolCallEnd {
+                name: Tool::Bash,
+                tool_use_id: None,
+                is_error: false,
+            })
+        );
+
+        let mut fail = raw("PostToolUse");
+        fail.tool_name = Some("exec".into());
+        fail.tool_response =
+            Some(serde_json::json!({"success": false, "output": "", "error": "boom"}));
+        assert_eq!(
+            fail.to_lifecycle_event(),
+            Some(LifecycleEvent::ToolCallEnd {
+                name: Tool::Bash,
+                tool_use_id: None,
+                is_error: true,
+            })
+        );
+    }
+
+    #[test]
+    fn permission_request_becomes_needs_input_with_tool_label() {
+        let mut e = raw("PermissionRequest");
+        e.tool_name = Some("exec".into());
+        assert_eq!(
+            e.to_lifecycle_event(),
+            Some(LifecycleEvent::NeedsInput {
+                reason: NeedsInputReason::Notification {
+                    kind: NotificationKind::PermissionPrompt,
+                    label: Some("exec".into()),
+                }
+            })
+        );
+    }
+
+    #[test]
+    fn user_prompt_carries_prompt() {
+        let mut e = raw("UserPromptSubmit");
+        e.prompt = Some("fix the tests".into());
+        assert_eq!(
+            e.to_lifecycle_event(),
+            Some(LifecycleEvent::PromptSubmit {
+                prompt: Some("fix the tests".into())
+            })
+        );
+    }
+
+    #[test]
+    fn stop_to_working_end() {
+        assert_eq!(
+            raw("Stop").to_lifecycle_event(),
+            Some(LifecycleEvent::WorkingEnd)
+        );
+    }
+
+    #[test]
+    fn post_compaction_to_notification() {
+        let mut e = raw("PostCompaction");
+        e.summary = Some("Compacted 40 messages".into());
+        assert_eq!(
+            e.to_lifecycle_event(),
+            Some(LifecycleEvent::Notification {
+                message: Some("Compacted 40 messages".into()),
+                kind: Some(NotificationKind::Info),
+            })
+        );
+    }
+
+    #[test]
+    fn session_start_carries_source() {
+        let mut e = raw("SessionStart");
+        e.source = Some("resume".into());
+        assert_eq!(
+            e.to_lifecycle_event(),
+            Some(LifecycleEvent::SessionStart {
+                source: Some("resume".into())
+            })
+        );
+    }
+
+    #[test]
+    fn session_end_carries_reason() {
+        let mut e = raw("SessionEnd");
+        e.reason = Some("user_exit".into());
+        assert_eq!(
+            e.to_lifecycle_event(),
+            Some(LifecycleEvent::SessionEnd {
+                reason: Some("user_exit".into())
+            })
+        );
+    }
+
+    #[test]
+    fn unknown_event_returns_none() {
+        assert_eq!(raw("NotARealEvent").to_lifecycle_event(), None);
+    }
+}

--- a/crates/atm-devin-adapter/src/wire.rs
+++ b/crates/atm-devin-adapter/src/wire.rs
@@ -1,0 +1,180 @@
+//! Raw Devin CLI hook-event payload (the JSON Devin sends on stdin to
+//! the hook script).
+//!
+//! Flat structure with all possible fields as `Option<T>` — mirrors
+//! [`atm_claude_adapter::wire::RawHookEvent`] since Devin's hook
+//! envelope shape is close to Claude's. Use
+//! [`RawDevinHookEvent::to_lifecycle_event`] to convert into a
+//! vendor-neutral `LifecycleEvent`.
+
+use atm_core::SessionId;
+use serde::Deserialize;
+
+use crate::event::DevinEventType;
+
+/// Raw hook event JSON structure from Devin CLI.
+///
+/// Use typed conversion ([`Self::to_lifecycle_event`]) for domain-layer
+/// type safety; the daemon never matches on `hook_event_name` strings.
+#[derive(Debug, Clone, Deserialize)]
+pub struct RawDevinHookEvent {
+    // === Common Fields (all events) ===
+    pub session_id: String,
+    pub hook_event_name: String,
+    /// Per-turn id, rotated on every user prompt. Absent for events
+    /// that fire before the first user prompt (e.g. `SessionStart`).
+    #[serde(default)]
+    pub prompt_id: Option<String>,
+
+    // === Injected by hook script ===
+    #[serde(default)]
+    pub pid: Option<u32>,
+    #[serde(default)]
+    pub tmux_pane: Option<String>,
+
+    // === Tool Events (PreToolUse, PostToolUse, PermissionRequest) ===
+    #[serde(default)]
+    pub tool_name: Option<String>,
+    #[serde(default)]
+    pub tool_input: Option<serde_json::Value>,
+    #[serde(default)]
+    pub tool_response: Option<serde_json::Value>,
+
+    // === User Prompt (UserPromptSubmit) ===
+    #[serde(default)]
+    pub prompt: Option<String>,
+
+    // === Stop ===
+    #[serde(default)]
+    pub stop_hook_active: Option<bool>,
+
+    // === PostCompaction ===
+    #[serde(default)]
+    pub summary: Option<String>,
+
+    // === Session Events (SessionStart, SessionEnd) ===
+    #[serde(default)]
+    pub source: Option<String>,
+    #[serde(default)]
+    pub reason: Option<String>,
+}
+
+impl RawDevinHookEvent {
+    /// Parses the hook event type.
+    pub fn event_type(&self) -> Option<DevinEventType> {
+        DevinEventType::from_event_name(&self.hook_event_name)
+    }
+
+    /// Returns the session ID.
+    pub fn session_id(&self) -> SessionId {
+        SessionId::new(&self.session_id)
+    }
+
+    /// Returns true if `tool_response` reports failure.
+    ///
+    /// Devin, unlike Claude, does not split tool failure into a
+    /// separate `PostToolUseFailure` event — `PostToolUse` fires for
+    /// both outcomes, and `tool_response.success` distinguishes them.
+    /// Defaults to `false` (success) when absent or malformed, since
+    /// a missing field shouldn't be treated as a failure signal.
+    #[must_use]
+    pub fn tool_failed(&self) -> bool {
+        self.tool_response
+            .as_ref()
+            .and_then(|r| r.get("success"))
+            .and_then(serde_json::Value::as_bool)
+            .map(|success| !success)
+            .unwrap_or(false)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_pre_tool_use() {
+        let json = r#"{
+            "session_id": "test-123",
+            "hook_event_name": "PreToolUse",
+            "tool_name": "exec",
+            "tool_input": {"command": "ls"}
+        }"#;
+        let event: RawDevinHookEvent = serde_json::from_str(json).unwrap();
+        assert_eq!(event.event_type(), Some(DevinEventType::PreToolUse));
+        assert_eq!(event.tool_name.as_deref(), Some("exec"));
+    }
+
+    #[test]
+    fn parse_post_tool_use_success() {
+        let json = r#"{
+            "session_id": "test-123",
+            "hook_event_name": "PostToolUse",
+            "tool_name": "exec",
+            "tool_response": {"success": true, "output": "ok", "error": null}
+        }"#;
+        let event: RawDevinHookEvent = serde_json::from_str(json).unwrap();
+        assert!(!event.tool_failed());
+    }
+
+    #[test]
+    fn parse_post_tool_use_failure() {
+        let json = r#"{
+            "session_id": "test-123",
+            "hook_event_name": "PostToolUse",
+            "tool_name": "exec",
+            "tool_response": {"success": false, "output": "", "error": "boom"}
+        }"#;
+        let event: RawDevinHookEvent = serde_json::from_str(json).unwrap();
+        assert!(event.tool_failed());
+    }
+
+    #[test]
+    fn parse_permission_request() {
+        let json = r#"{
+            "session_id": "test-123",
+            "hook_event_name": "PermissionRequest",
+            "tool_name": "exec",
+            "tool_input": {"command": "rm -rf /"}
+        }"#;
+        let event: RawDevinHookEvent = serde_json::from_str(json).unwrap();
+        assert_eq!(event.event_type(), Some(DevinEventType::PermissionRequest));
+    }
+
+    #[test]
+    fn parse_user_prompt_submit() {
+        let json = r#"{
+            "session_id": "test-123",
+            "hook_event_name": "UserPromptSubmit",
+            "prompt": "fix the tests"
+        }"#;
+        let event: RawDevinHookEvent = serde_json::from_str(json).unwrap();
+        assert_eq!(event.prompt.as_deref(), Some("fix the tests"));
+    }
+
+    #[test]
+    fn parse_post_compaction() {
+        let json = r#"{
+            "session_id": "test-123",
+            "hook_event_name": "PostCompaction",
+            "summary": "Compacted 40 messages"
+        }"#;
+        let event: RawDevinHookEvent = serde_json::from_str(json).unwrap();
+        assert_eq!(event.summary.as_deref(), Some("Compacted 40 messages"));
+    }
+
+    #[test]
+    fn parse_session_start_and_end() {
+        let start: RawDevinHookEvent = serde_json::from_str(
+            r#"{"session_id":"s","hook_event_name":"SessionStart","source":"resume"}"#,
+        )
+        .unwrap();
+        assert_eq!(start.source.as_deref(), Some("resume"));
+
+        let end: RawDevinHookEvent = serde_json::from_str(
+            r#"{"session_id":"s","hook_event_name":"SessionEnd","reason":"user_exit"}"#,
+        )
+        .unwrap();
+        assert_eq!(end.reason.as_deref(), Some("user_exit"));
+    }
+}

--- a/crates/atm-protocol/src/message.rs
+++ b/crates/atm-protocol/src/message.rs
@@ -36,6 +36,22 @@ pub enum MessageType {
         data: serde_json::Value,
     },
 
+    /// Hook event from Devin CLI (raw `RawDevinHookEvent` payload).
+    /// Translated by `atm-devin-adapter` at the daemon boundary.
+    /// Symmetric with [`Self::HookEvent`].
+    DevinEvent {
+        /// The raw hook event JSON (to be parsed)
+        data: serde_json::Value,
+    },
+
+    /// Hook event from GitHub Copilot CLI (raw `RawCopilotHookEvent`
+    /// payload). Translated by `atm-copilot-adapter` at the daemon
+    /// boundary. Symmetric with [`Self::HookEvent`].
+    CopilotEvent {
+        /// The raw hook event JSON (to be parsed)
+        data: serde_json::Value,
+    },
+
     /// Request current session list
     ListSessions,
 
@@ -100,6 +116,16 @@ impl ClientMessage {
     /// Creates a pi event message (raw pi-extension payload).
     pub fn pi_event(data: serde_json::Value) -> Self {
         Self::new(MessageType::PiEvent { data })
+    }
+
+    /// Creates a Devin CLI hook event message (Devin raw payload).
+    pub fn devin_event(data: serde_json::Value) -> Self {
+        Self::new(MessageType::DevinEvent { data })
+    }
+
+    /// Creates a Copilot CLI hook event message (Copilot raw payload).
+    pub fn copilot_event(data: serde_json::Value) -> Self {
+        Self::new(MessageType::CopilotEvent { data })
     }
 
     /// Creates a list sessions request.

--- a/crates/atm/scripts/atm-copilot-hook
+++ b/crates/atm/scripts/atm-copilot-hook
@@ -1,0 +1,108 @@
+#!/bin/bash
+# ATM Hook - GitHub Copilot CLI hook handler
+#
+# Copilot CLI's per-event hook payload (see
+# https://docs.github.com/en/copilot/reference/hooks-reference) does not
+# include a "which event is this" field — the event kind is implied by
+# which array in hooks.json the command was registered under. atm's
+# generated ~/.copilot/hooks/atm.json therefore invokes this script with
+# the event name as $1 for every event array, and this script injects it
+# into the JSON envelope as `hookEventName` before forwarding to atmd —
+# see atm_copilot_adapter::wire for the receiving side.
+#
+# CRITICAL: This script MUST:
+# - Always exit 0 (never break Copilot CLI)
+# - Be non-blocking
+# - Handle daemon unavailability gracefully
+# - Be portable: Linux and macOS both run Copilot CLI, so process-tree
+#   walking uses `ps` rather than assuming /proc exists.
+
+set -o pipefail
+
+EVENT_NAME="${1:-}"
+SOCKET="${ATM_SOCKET:-/tmp/atm.sock}"
+DEBUG="${ATM_DEBUG:-0}"
+
+log_debug() {
+    if [ "$DEBUG" = "1" ]; then
+        echo "$(date -Iseconds 2>/dev/null || date) [atm-copilot-hook] $1" >> /tmp/atm-hook.log
+    fi
+}
+
+find_copilot_pid() {
+    local pid=$PPID
+    local copilot_pid=""
+    local depth=0
+    local max_depth=15
+
+    while [ "$depth" -lt "$max_depth" ] && [ -n "$pid" ] && [ "$pid" != "1" ] && [ "$pid" != "0" ]; do
+        local comm
+        comm=$(ps -o comm= -p "$pid" 2>/dev/null | tr -d ' ')
+        comm=$(basename "$comm" 2>/dev/null || echo "$comm")
+        [ "$comm" = "copilot" ] && copilot_pid=$pid
+        pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' ')
+        depth=$((depth + 1))
+    done
+
+    echo "${copilot_pid:-}"
+}
+
+if [ -z "$EVENT_NAME" ]; then
+    log_debug "No event name argument passed"
+    exit 0
+fi
+
+if [ ! -S "$SOCKET" ]; then
+    log_debug "Socket not found: $SOCKET"
+    exit 0
+fi
+
+input=$(cat)
+if [ -z "$input" ]; then
+    input="{}"
+fi
+
+SESSION_ID=$(echo "$input" | jq -r '.sessionId // empty' 2>/dev/null)
+if [ -z "$SESSION_ID" ]; then
+    log_debug "No sessionId in input for $EVENT_NAME"
+    exit 0
+fi
+
+log_debug "Hook: $EVENT_NAME for session $SESSION_ID"
+
+COPILOT_PID=$(find_copilot_pid)
+
+CONNECT_MSG=$(cat <<EOF
+{"protocol_version":{"major":1,"minor":0},"type":"connect","client_id":"copilot-hook-$SESSION_ID-$$"}
+EOF
+)
+
+TMUX_PANE_ID="${TMUX_PANE:-}"
+EXTRA_JSON=$(jq -cn --arg event "$EVENT_NAME" '{hookEventName: $event}')
+[ -n "$COPILOT_PID" ] && EXTRA_JSON=$(echo "$EXTRA_JSON" | jq -c --argjson pid "$COPILOT_PID" '. + {pid: $pid}')
+[ -n "$TMUX_PANE_ID" ] && EXTRA_JSON=$(echo "$EXTRA_JSON" | jq -c --arg tmux_pane "$TMUX_PANE_ID" '. + {tmuxPane: $tmux_pane}')
+
+DATA_MSG=$(jq -c --argjson extra "$EXTRA_JSON" '{
+    "protocol_version": {"major": 1, "minor": 0},
+    "type": "copilot_event",
+    "data": (. + $extra)
+}' <<< "$input" 2>/dev/null)
+
+if [ -z "$DATA_MSG" ] || [ "$DATA_MSG" = "null" ]; then
+    log_debug "Failed to build message"
+    exit 0
+fi
+
+if command -v socat &>/dev/null; then
+    { echo "$CONNECT_MSG"; echo "$DATA_MSG"; } | socat -t0.1 - "UNIX-CONNECT:$SOCKET" >/dev/null 2>&1 || {
+        log_debug "Failed to send via socat"
+    }
+else
+    { echo "$CONNECT_MSG"; echo "$DATA_MSG"; } | nc -U "$SOCKET" >/dev/null 2>&1 || {
+        log_debug "Failed to send via nc"
+    }
+fi
+
+log_debug "Message sent successfully"
+
+exit 0

--- a/crates/atm/scripts/atm-copilot-hook
+++ b/crates/atm/scripts/atm-copilot-hook
@@ -98,7 +98,7 @@ if command -v socat &>/dev/null; then
         log_debug "Failed to send via socat"
     }
 else
-    { echo "$CONNECT_MSG"; echo "$DATA_MSG"; } | nc -U "$SOCKET" >/dev/null 2>&1 || {
+    { echo "$CONNECT_MSG"; echo "$DATA_MSG"; } | nc -w 1 -U "$SOCKET" >/dev/null 2>&1 || {
         log_debug "Failed to send via nc"
     }
 fi

--- a/crates/atm/scripts/atm-devin-hook
+++ b/crates/atm/scripts/atm-devin-hook
@@ -93,7 +93,7 @@ if command -v socat &>/dev/null; then
         log_debug "Failed to send via socat"
     }
 else
-    { echo "$CONNECT_MSG"; echo "$DATA_MSG"; } | nc -U "$SOCKET" >/dev/null 2>&1 || {
+    { echo "$CONNECT_MSG"; echo "$DATA_MSG"; } | nc -w 1 -U "$SOCKET" >/dev/null 2>&1 || {
         log_debug "Failed to send via nc"
     }
 fi

--- a/crates/atm/scripts/atm-devin-hook
+++ b/crates/atm/scripts/atm-devin-hook
@@ -1,0 +1,103 @@
+#!/bin/bash
+# ATM Hook - Devin CLI hook handler
+# Handles all Devin CLI hook events: PreToolUse, PostToolUse, etc.
+#
+# Devin CLI's hook envelope (https://docs.devin.ai/cli/extensibility/hooks/overview)
+# already carries `hook_event_name` and `session_id` on stdin, so unlike
+# atm-copilot-hook this script doesn't need an event-name argument.
+#
+# CRITICAL: This script MUST:
+# - Always exit 0 (never break Devin CLI)
+# - Be non-blocking
+# - Handle daemon unavailability gracefully
+# - Be portable: Linux and macOS both run Devin CLI, so process-tree
+#   walking uses `ps` rather than assuming /proc exists.
+
+set -o pipefail
+
+SOCKET="${ATM_SOCKET:-/tmp/atm.sock}"
+DEBUG="${ATM_DEBUG:-0}"
+
+log_debug() {
+    if [ "$DEBUG" = "1" ]; then
+        echo "$(date -Iseconds 2>/dev/null || date) [atm-devin-hook] $1" >> /tmp/atm-hook.log
+    fi
+}
+
+# Find the actual Devin CLI process by walking up the process tree via
+# `ps` (works on Linux and macOS, unlike /proc-based walks).
+find_devin_pid() {
+    local pid=$PPID
+    local devin_pid=""
+    local depth=0
+    local max_depth=15
+
+    while [ "$depth" -lt "$max_depth" ] && [ -n "$pid" ] && [ "$pid" != "1" ] && [ "$pid" != "0" ]; do
+        local comm
+        comm=$(ps -o comm= -p "$pid" 2>/dev/null | tr -d ' ')
+        comm=$(basename "$comm" 2>/dev/null || echo "$comm")
+        [ "$comm" = "devin" ] && devin_pid=$pid
+        pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' ')
+        depth=$((depth + 1))
+    done
+
+    echo "${devin_pid:-}"
+}
+
+if [ ! -S "$SOCKET" ]; then
+    log_debug "Socket not found: $SOCKET"
+    exit 0
+fi
+
+input=$(cat)
+
+if [ -z "$input" ]; then
+    log_debug "Empty input received"
+    exit 0
+fi
+
+SESSION_ID=$(echo "$input" | jq -r '.session_id // empty' 2>/dev/null)
+if [ -z "$SESSION_ID" ]; then
+    log_debug "No session_id in input"
+    exit 0
+fi
+
+HOOK_EVENT=$(echo "$input" | jq -r '.hook_event_name // empty' 2>/dev/null)
+log_debug "Hook: $HOOK_EVENT for session $SESSION_ID"
+
+DEVIN_PID=$(find_devin_pid)
+
+CONNECT_MSG=$(cat <<EOF
+{"protocol_version":{"major":1,"minor":0},"type":"connect","client_id":"devin-hook-$SESSION_ID-$$"}
+EOF
+)
+
+TMUX_PANE_ID="${TMUX_PANE:-}"
+EXTRA_JSON="{}"
+[ -n "$DEVIN_PID" ] && EXTRA_JSON=$(echo "$EXTRA_JSON" | jq -c --argjson pid "$DEVIN_PID" '. + {pid: $pid}')
+[ -n "$TMUX_PANE_ID" ] && EXTRA_JSON=$(echo "$EXTRA_JSON" | jq -c --arg tmux_pane "$TMUX_PANE_ID" '. + {tmux_pane: $tmux_pane}')
+
+DATA_MSG=$(jq -c --argjson extra "$EXTRA_JSON" '{
+    "protocol_version": {"major": 1, "minor": 0},
+    "type": "devin_event",
+    "data": (. + $extra)
+}' <<< "$input" 2>/dev/null)
+
+if [ -z "$DATA_MSG" ] || [ "$DATA_MSG" = "null" ]; then
+    log_debug "Failed to build message"
+    exit 0
+fi
+
+if command -v socat &>/dev/null; then
+    { echo "$CONNECT_MSG"; echo "$DATA_MSG"; } | socat -t0.1 - "UNIX-CONNECT:$SOCKET" >/dev/null 2>&1 || {
+        log_debug "Failed to send via socat"
+    }
+else
+    { echo "$CONNECT_MSG"; echo "$DATA_MSG"; } | nc -U "$SOCKET" >/dev/null 2>&1 || {
+        log_debug "Failed to send via nc"
+    }
+fi
+
+log_debug "Message sent successfully"
+
+exit 0

--- a/crates/atm/src/setup.rs
+++ b/crates/atm/src/setup.rs
@@ -607,8 +607,11 @@ pub fn setup() -> Result<()> {
         if devin { "✓" } else { "✗" },
         if devin { "" } else { " not present" }
     );
+    let copilot_home_display = copilot_home_dir()
+        .map(|p| p.display().to_string())
+        .unwrap_or_else(|| "~/.copilot".to_string());
     println!(
-        "  {} Copilot CLI  (~/.copilot/{})",
+        "  {} Copilot CLI  ({copilot_home_display}/{})",
         if copilot { "✓" } else { "✗" },
         if copilot { "" } else { " not present" }
     );
@@ -848,10 +851,12 @@ fn setup_copilot() -> Result<()> {
         } else {
             // Copilot invokes the same script for every event array,
             // so the event name is passed as an argument — see
-            // atm-copilot-hook and atm_copilot_adapter::wire.
+            // atm-copilot-hook and atm_copilot_adapter::wire. Quote
+            // the script path so a space in $HOME (or an unusual
+            // install location) doesn't split into the wrong argv.
             hooks_array.push(json!({
                 "type": "command",
-                "command": format!("{command_path} {hook_type}"),
+                "command": format!("'{command_path}' {hook_type}"),
             }));
             added += 1;
             println!("    {hook_type} - added");

--- a/crates/atm/src/setup.rs
+++ b/crates/atm/src/setup.rs
@@ -24,6 +24,12 @@ use serde_json::{json, Value};
 /// The atm-hook bash script content (Claude Code), embedded at compile time.
 const ATM_HOOK_SCRIPT: &str = include_str!("../scripts/atm-hook");
 
+/// The atm-devin-hook bash script content (Devin CLI), embedded at compile time.
+const ATM_DEVIN_HOOK_SCRIPT: &str = include_str!("../scripts/atm-devin-hook");
+
+/// The atm-copilot-hook bash script content (GitHub Copilot CLI), embedded at compile time.
+const ATM_COPILOT_HOOK_SCRIPT: &str = include_str!("../scripts/atm-copilot-hook");
+
 /// The pi-atm TypeScript extension content, embedded at compile time.
 /// pi loads `.ts` files directly via `@mariozechner/jiti`.
 const PI_ATM_EXTENSION: &str = include_str!("../assets/pi-atm/extensions/pi-atm.ts");
@@ -50,16 +56,83 @@ const HOOK_TYPES: &[&str] = &[
     "PermissionRequest",
 ];
 
+/// Devin CLI hook types atm wires up.
+/// See: https://docs.devin.ai/cli/extensibility/hooks/overview
+const DEVIN_HOOK_TYPES: &[&str] = &[
+    "PreToolUse",
+    "PostToolUse",
+    "PermissionRequest",
+    "UserPromptSubmit",
+    "Stop",
+    "PostCompaction",
+    "SessionStart",
+    "SessionEnd",
+];
+
+/// Copilot CLI hook types atm wires up (hooks.json event keys — camelCase).
+/// See: https://docs.github.com/en/copilot/reference/hooks-reference
+const COPILOT_HOOK_TYPES: &[&str] = &[
+    "preToolUse",
+    "postToolUse",
+    "postToolUseFailure",
+    "permissionRequest",
+    "userPromptSubmitted",
+    "sessionStart",
+    "sessionEnd",
+];
+
 /// Returns the path to Claude Code settings.json
 fn claude_settings_path() -> Option<PathBuf> {
     dirs::home_dir().map(|h| h.join(".claude").join("settings.json"))
 }
 
-/// Returns the path to the atm-hook script
+/// Returns the path to Devin CLI's user-wide config file.
+///
+/// Devin CLI hardcodes `~/.config/devin/config.json` on both macOS and
+/// Linux (only Windows differs, using `%APPDATA%\devin\config.json`) —
+/// unlike `dirs::config_dir()`, which resolves to
+/// `~/Library/Application Support` on macOS. So this is built from
+/// `home_dir()` directly rather than reusing `dirs::config_dir()`.
+fn devin_config_path() -> Option<PathBuf> {
+    dirs::home_dir().map(|h| h.join(".config").join("devin").join("config.json"))
+}
+
+/// Returns Copilot CLI's home directory: `$COPILOT_HOME` if set,
+/// otherwise `~/.copilot`.
+fn copilot_home_dir() -> Option<PathBuf> {
+    if let Some(dir) = std::env::var_os("COPILOT_HOME") {
+        let path = PathBuf::from(dir);
+        if !path.as_os_str().is_empty() {
+            return Some(path);
+        }
+    }
+    dirs::home_dir().map(|h| h.join(".copilot"))
+}
+
+/// Returns the path to atm's standalone Copilot CLI user-level hooks file.
+fn copilot_hooks_file_path() -> Option<PathBuf> {
+    copilot_home_dir().map(|h| h.join("hooks").join("atm.json"))
+}
+
+/// Returns the path to the atm-hook script (Claude Code).
 fn hook_script_path() -> PathBuf {
     dirs::home_dir()
         .map(|h| h.join(".local").join("bin").join("atm-hook"))
         .unwrap_or_else(|| PathBuf::from("/usr/local/bin/atm-hook"))
+}
+
+/// Returns the path to the atm-devin-hook script.
+fn devin_hook_script_path() -> PathBuf {
+    dirs::home_dir()
+        .map(|h| h.join(".local").join("bin").join("atm-devin-hook"))
+        .unwrap_or_else(|| PathBuf::from("/usr/local/bin/atm-devin-hook"))
+}
+
+/// Returns the path to the atm-copilot-hook script.
+fn copilot_hook_script_path() -> PathBuf {
+    dirs::home_dir()
+        .map(|h| h.join(".local").join("bin").join("atm-copilot-hook"))
+        .unwrap_or_else(|| PathBuf::from("/usr/local/bin/atm-copilot-hook"))
 }
 
 /// Reads a JSON file at `path`, returning an empty object if the file
@@ -121,13 +194,13 @@ fn has_atm_status_line(status_line: &Value) -> bool {
         .unwrap_or(false)
 }
 
-/// Creates a hook entry for the given hook type.
+/// Creates a hook entry for the given hook type, in Claude Code /
+/// Devin CLI's shared `{matcher, hooks: [{type, command}]}` shape.
 ///
 /// Hook types that filter by tool name use a matcher, others don't.
-fn create_hook_entry(hook_type: &str) -> Value {
-    let hook_path = hook_script_path();
-    let command = hook_path.to_string_lossy().to_string();
-
+/// `command` is the full command line to run (typically an installed
+/// hook script's path).
+fn create_hook_entry(hook_type: &str, command: &str) -> Value {
     // Tool-related hooks use a matcher to filter by tool name
     let needs_matcher = matches!(
         hook_type,
@@ -153,8 +226,10 @@ fn create_hook_entry(hook_type: &str) -> Value {
     }
 }
 
-/// Checks if atm hooks are already installed for a hook type
-fn has_atm_hook(hooks_array: &[Value]) -> bool {
+/// Checks if a hook entries array already contains a command matching
+/// `marker` (a distinguishing substring of an atm-installed hook
+/// script's path, e.g. `"atm-hook"`, `"atm-devin-hook"`).
+fn has_atm_hook(hooks_array: &[Value], marker: &str) -> bool {
     hooks_array.iter().any(|entry| {
         entry
             .get("hooks")
@@ -163,7 +238,7 @@ fn has_atm_hook(hooks_array: &[Value]) -> bool {
                 hooks.iter().any(|hook| {
                     hook.get("command")
                         .and_then(|c| c.as_str())
-                        .map(|cmd| cmd.contains("atm-hook"))
+                        .map(|cmd| cmd.contains(marker))
                         .unwrap_or(false)
                 })
             })
@@ -171,8 +246,9 @@ fn has_atm_hook(hooks_array: &[Value]) -> bool {
     })
 }
 
-/// Removes atm hooks from a hooks array
-fn remove_atm_hooks(hooks_array: &mut Vec<Value>) {
+/// Removes hook entries matching `marker` from a hooks array (see
+/// [`has_atm_hook`]).
+fn remove_atm_hooks(hooks_array: &mut Vec<Value>, marker: &str) {
     hooks_array.retain(|entry| {
         !entry
             .get("hooks")
@@ -181,7 +257,7 @@ fn remove_atm_hooks(hooks_array: &mut Vec<Value>) {
                 hooks.iter().any(|hook| {
                     hook.get("command")
                         .and_then(|c| c.as_str())
-                        .map(|cmd| cmd.contains("atm-hook"))
+                        .map(|cmd| cmd.contains(marker))
                         .unwrap_or(false)
                 })
             })
@@ -189,32 +265,47 @@ fn remove_atm_hooks(hooks_array: &mut Vec<Value>) {
     });
 }
 
-/// Installs the atm-hook script to ~/.local/bin/
+/// Installs a hook script to `path` with the given `content`.
 ///
-/// Creates the directory if it doesn't exist and sets executable permissions.
-fn install_hook_script() -> Result<()> {
-    let hook_path = hook_script_path();
-
+/// Creates the parent directory if it doesn't exist and sets
+/// executable permissions. Shared by the Claude Code, Devin CLI, and
+/// Copilot CLI hook scripts — each vendor just supplies its own path
+/// and embedded script content.
+fn install_hook_script_at(path: &Path, content: &str) -> Result<()> {
     // Create parent directory if needed
-    if let Some(parent) = hook_path.parent() {
+    if let Some(parent) = path.parent() {
         fs::create_dir_all(parent)
             .with_context(|| format!("Failed to create {}", parent.display()))?;
     }
 
     // Write the script
-    fs::write(&hook_path, ATM_HOOK_SCRIPT)
-        .with_context(|| format!("Failed to write {}", hook_path.display()))?;
+    fs::write(path, content).with_context(|| format!("Failed to write {}", path.display()))?;
 
     // Make executable on Unix
     #[cfg(unix)]
     {
-        let mut perms = fs::metadata(&hook_path)?.permissions();
+        let mut perms = fs::metadata(path)?.permissions();
         perms.set_mode(0o755);
-        fs::set_permissions(&hook_path, perms)
-            .with_context(|| format!("Failed to set permissions on {}", hook_path.display()))?;
+        fs::set_permissions(path, perms)
+            .with_context(|| format!("Failed to set permissions on {}", path.display()))?;
     }
 
     Ok(())
+}
+
+/// Installs the atm-hook script (Claude Code) to ~/.local/bin/.
+fn install_hook_script() -> Result<()> {
+    install_hook_script_at(&hook_script_path(), ATM_HOOK_SCRIPT)
+}
+
+/// Installs the atm-devin-hook script (Devin CLI) to ~/.local/bin/.
+fn install_devin_hook_script() -> Result<()> {
+    install_hook_script_at(&devin_hook_script_path(), ATM_DEVIN_HOOK_SCRIPT)
+}
+
+/// Installs the atm-copilot-hook script (Copilot CLI) to ~/.local/bin/.
+fn install_copilot_hook_script() -> Result<()> {
+    install_hook_script_at(&copilot_hook_script_path(), ATM_COPILOT_HOOK_SCRIPT)
 }
 
 /// Installs the ATM tmux keybindings file to ~/.config/atm/tmux-bindings.conf.
@@ -281,6 +372,25 @@ fn detect_pi() -> bool {
     dirs::home_dir()
         .map(|h| h.join(".pi/agent").exists())
         .unwrap_or(false)
+}
+
+/// True if Devin CLI appears to be installed for this user.
+///
+/// Devin CLI creates `~/.config/devin/` on first run regardless of
+/// where its binary lives, mirroring the Claude Code / pi detection
+/// strategy above.
+fn detect_devin() -> bool {
+    devin_config_path()
+        .and_then(|p| p.parent().map(Path::exists))
+        .unwrap_or(false)
+}
+
+/// True if Copilot CLI appears to be installed for this user.
+///
+/// Copilot CLI creates its home directory (`~/.copilot`, or
+/// `$COPILOT_HOME` if set) on first run.
+fn detect_copilot() -> bool {
+    copilot_home_dir().map(|p| p.exists()).unwrap_or(false)
 }
 
 // ============================================================================
@@ -391,17 +501,29 @@ fn uninstall_pi_extension() -> Result<bool> {
     Ok(changed)
 }
 
-/// Removes the atm-hook script from ~/.local/bin/
-fn remove_hook_script() -> Result<bool> {
-    let hook_path = hook_script_path();
-
-    if hook_path.exists() {
-        fs::remove_file(&hook_path)
-            .with_context(|| format!("Failed to remove {}", hook_path.display()))?;
+/// Removes a hook script at `path`, if present.
+fn remove_hook_script_at(path: &Path) -> Result<bool> {
+    if path.exists() {
+        fs::remove_file(path).with_context(|| format!("Failed to remove {}", path.display()))?;
         Ok(true)
     } else {
         Ok(false)
     }
+}
+
+/// Removes the atm-hook script (Claude Code) from ~/.local/bin/.
+fn remove_hook_script() -> Result<bool> {
+    remove_hook_script_at(&hook_script_path())
+}
+
+/// Removes the atm-devin-hook script from ~/.local/bin/.
+fn remove_devin_hook_script() -> Result<bool> {
+    remove_hook_script_at(&devin_hook_script_path())
+}
+
+/// Removes the atm-copilot-hook script from ~/.local/bin/.
+fn remove_copilot_hook_script() -> Result<bool> {
+    remove_hook_script_at(&copilot_hook_script_path())
 }
 
 /// Returns the path to atm's own configuration file (`$XDG_CONFIG_HOME/atm/config.toml`).
@@ -466,6 +588,8 @@ pub fn setup() -> Result<()> {
     // will (and won't) be configured.
     let claude = detect_claude_code();
     let pi = detect_pi();
+    let devin = detect_devin();
+    let copilot = detect_copilot();
 
     println!("Detected coding agents:");
     println!(
@@ -478,9 +602,21 @@ pub fn setup() -> Result<()> {
         if pi { "✓" } else { "✗" },
         if pi { "" } else { " not present" }
     );
+    println!(
+        "  {} Devin CLI    (~/.config/devin/{})",
+        if devin { "✓" } else { "✗" },
+        if devin { "" } else { " not present" }
+    );
+    println!(
+        "  {} Copilot CLI  (~/.copilot/{})",
+        if copilot { "✓" } else { "✗" },
+        if copilot { "" } else { " not present" }
+    );
 
-    if !claude && !pi {
-        println!("\nNo supported agent installations found. Install Claude Code or pi first.");
+    if !claude && !pi && !devin && !copilot {
+        println!(
+            "\nNo supported agent installations found. Install Claude Code, pi, Devin CLI, or Copilot CLI first."
+        );
         return Ok(());
     }
 
@@ -490,6 +626,14 @@ pub fn setup() -> Result<()> {
 
     if pi {
         setup_pi()?;
+    }
+
+    if devin {
+        setup_devin()?;
+    }
+
+    if copilot {
+        setup_copilot()?;
     }
 
     // Step N: Install tmux keybindings (vendor-neutral).
@@ -533,6 +677,7 @@ fn setup_claude_code() -> Result<()> {
         .context("hooks is not an object")?;
 
     let mut added = 0;
+    let command = hook_path.to_string_lossy().to_string();
 
     for &hook_type in HOOK_TYPES {
         let hooks_array = hooks
@@ -541,10 +686,10 @@ fn setup_claude_code() -> Result<()> {
             .as_array_mut()
             .context("hook type is not an array")?;
 
-        if has_atm_hook(hooks_array) {
+        if has_atm_hook(hooks_array, "atm-hook") {
             println!("    {hook_type} - already configured");
         } else {
-            hooks_array.push(create_hook_entry(hook_type));
+            hooks_array.push(create_hook_entry(hook_type, &command));
             added += 1;
             println!("    {hook_type} - added");
         }
@@ -593,6 +738,135 @@ fn setup_pi() -> Result<()> {
     Ok(())
 }
 
+/// Wires `atm-devin-hook` into Devin CLI's `~/.config/devin/config.json`.
+///
+/// Devin CLI's hook config format is the same
+/// `{matcher, hooks: [{type, command}]}` shape Claude Code uses (see
+/// module docs), so this reuses [`create_hook_entry`] /
+/// [`has_atm_hook`] / [`remove_atm_hooks`] with a distinct
+/// `"atm-devin-hook"` marker.
+fn setup_devin() -> Result<()> {
+    println!("\nConfiguring Devin CLI...");
+    let hook_path = devin_hook_script_path();
+    print!("  Installing hook script to {}... ", hook_path.display());
+    install_devin_hook_script()?;
+    println!("done");
+
+    let path = devin_config_path().context("Could not determine home directory")?;
+    let mut config = read_json_file_or_empty(&path)?;
+    if !config.is_object() {
+        config = json!({});
+    }
+    if config.get("hooks").is_none() {
+        config["hooks"] = json!({});
+    }
+
+    let hooks = config["hooks"]
+        .as_object_mut()
+        .context("hooks is not an object")?;
+
+    let mut added = 0;
+    let command = hook_path.to_string_lossy().to_string();
+
+    for &hook_type in DEVIN_HOOK_TYPES {
+        let hooks_array = hooks
+            .entry(hook_type)
+            .or_insert_with(|| json!([]))
+            .as_array_mut()
+            .context("hook type is not an array")?;
+
+        if has_atm_hook(hooks_array, "atm-devin-hook") {
+            println!("    {hook_type} - already configured");
+        } else {
+            hooks_array.push(create_hook_entry(hook_type, &command));
+            added += 1;
+            println!("    {hook_type} - added");
+        }
+    }
+
+    if added > 0 {
+        write_json_file_pretty(&path, &config)?;
+        println!("  Devin CLI configuration written.");
+    } else {
+        println!("  Devin CLI already configured.");
+    }
+    Ok(())
+}
+
+/// Checks if a Copilot-style flat hook-entries array already contains
+/// a command matching `marker`.
+///
+/// Unlike Claude/Devin's `{matcher, hooks: [...]}` nesting, Copilot's
+/// `hooks.json` format is a flat array of `{type, command, ...}`
+/// objects per event.
+fn has_atm_copilot_hook(hooks_array: &[Value], marker: &str) -> bool {
+    hooks_array.iter().any(|hook| {
+        hook.get("command")
+            .and_then(|c| c.as_str())
+            .map(|cmd| cmd.contains(marker))
+            .unwrap_or(false)
+    })
+}
+
+/// Wires `atm-copilot-hook` into Copilot CLI's standalone user-level
+/// hooks file (`~/.copilot/hooks/atm.json`).
+fn setup_copilot() -> Result<()> {
+    println!("\nConfiguring Copilot CLI...");
+    let hook_path = copilot_hook_script_path();
+    print!("  Installing hook script to {}... ", hook_path.display());
+    install_copilot_hook_script()?;
+    println!("done");
+
+    let path = copilot_hooks_file_path().context("Could not determine Copilot CLI home dir")?;
+    let mut config = read_json_file_or_empty(&path)?;
+    if !config.is_object() {
+        config = json!({"version": 1});
+    }
+    if config.get("version").is_none() {
+        config["version"] = json!(1);
+    }
+    if config.get("hooks").is_none() {
+        config["hooks"] = json!({});
+    }
+
+    let hooks = config["hooks"]
+        .as_object_mut()
+        .context("hooks is not an object")?;
+
+    let mut added = 0;
+    let command_path = hook_path.to_string_lossy().to_string();
+
+    for &hook_type in COPILOT_HOOK_TYPES {
+        let hooks_array = hooks
+            .entry(hook_type)
+            .or_insert_with(|| json!([]))
+            .as_array_mut()
+            .context("hook type is not an array")?;
+
+        if has_atm_copilot_hook(hooks_array, "atm-copilot-hook") {
+            println!("    {hook_type} - already configured");
+        } else {
+            // Copilot invokes the same script for every event array,
+            // so the event name is passed as an argument — see
+            // atm-copilot-hook and atm_copilot_adapter::wire.
+            hooks_array.push(json!({
+                "type": "command",
+                "command": format!("{command_path} {hook_type}"),
+            }));
+            added += 1;
+            println!("    {hook_type} - added");
+        }
+    }
+
+    if added > 0 {
+        write_json_file_pretty(&path, &config)?;
+        println!("  Copilot CLI configuration written.");
+    } else {
+        println!("  Copilot CLI already configured.");
+    }
+    Ok(())
+}
+
 /// Removes atm hooks from Claude Code settings and the hook script
 pub fn uninstall() -> Result<()> {
     println!("Uninstalling ATM...\n");
@@ -606,7 +880,7 @@ pub fn uninstall() -> Result<()> {
         for &hook_type in HOOK_TYPES {
             if let Some(hooks_array) = hooks.get_mut(hook_type).and_then(|h| h.as_array_mut()) {
                 let before = hooks_array.len();
-                remove_atm_hooks(hooks_array);
+                remove_atm_hooks(hooks_array, "atm-hook");
                 let after = hooks_array.len();
 
                 if before != after {
@@ -665,7 +939,73 @@ pub fn uninstall() -> Result<()> {
         }
     }
 
+    // Step 5: Remove Devin CLI hooks and hook script
+    uninstall_devin()?;
+
+    // Step 6: Remove Copilot CLI hooks and hook script
+    uninstall_copilot()?;
+
     println!("\nATM uninstalled successfully!");
+    Ok(())
+}
+
+/// Removes atm hooks from Devin CLI's config and the atm-devin-hook script.
+fn uninstall_devin() -> Result<()> {
+    if let Some(path) = devin_config_path() {
+        if path.exists() {
+            let mut config = read_json_file_or_empty(&path)?;
+            let mut removed = 0;
+            if let Some(hooks) = config.get_mut("hooks").and_then(|h| h.as_object_mut()) {
+                for &hook_type in DEVIN_HOOK_TYPES {
+                    if let Some(hooks_array) =
+                        hooks.get_mut(hook_type).and_then(|h| h.as_array_mut())
+                    {
+                        let before = hooks_array.len();
+                        remove_atm_hooks(hooks_array, "atm-devin-hook");
+                        let after = hooks_array.len();
+                        removed += before - after;
+                        if hooks_array.is_empty() {
+                            hooks.remove(hook_type);
+                        }
+                    }
+                }
+                if removed > 0 {
+                    write_json_file_pretty(&path, &config)?;
+                }
+            }
+            println!(
+                "\nRemoved {removed} Devin CLI hook{} from {}",
+                if removed == 1 { "" } else { "s" },
+                path.display()
+            );
+        }
+    }
+
+    print!("Removing atm-devin-hook script... ");
+    if remove_devin_hook_script()? {
+        println!("done");
+    } else {
+        println!("not found");
+    }
+    Ok(())
+}
+
+/// Removes atm's standalone Copilot CLI hooks file and hook script.
+fn uninstall_copilot() -> Result<()> {
+    if let Some(path) = copilot_hooks_file_path() {
+        if path.exists() {
+            fs::remove_file(&path)
+                .with_context(|| format!("Failed to remove {}", path.display()))?;
+            println!("\nRemoved Copilot CLI hooks file {}", path.display());
+        }
+    }
+
+    print!("Removing atm-copilot-hook script... ");
+    if remove_copilot_hook_script()? {
+        println!("done");
+    } else {
+        println!("not found");
+    }
     Ok(())
 }
 

--- a/crates/atmd/Cargo.toml
+++ b/crates/atmd/Cargo.toml
@@ -24,6 +24,8 @@ atm-core = { workspace = true }
 atm-protocol = { workspace = true }
 atm-claude-adapter = { workspace = true }
 atm-pi-adapter = { workspace = true }
+atm-devin-adapter = { workspace = true }
+atm-copilot-adapter = { workspace = true }
 tokio = { workspace = true }
 tokio-util = { workspace = true }
 serde = { workspace = true }

--- a/crates/atmd/src/discovery.rs
+++ b/crates/atmd/src/discovery.rs
@@ -716,6 +716,6 @@ mod tests {
             .filter(|definition| definition.discovery_enabled)
             .map(|definition| definition.id)
             .collect();
-        assert_eq!(enabled, vec!["claude", "pi"]);
+        assert_eq!(enabled, vec!["claude", "pi", "devin", "copilot"]);
     }
 }

--- a/crates/atmd/src/server/connection.rs
+++ b/crates/atmd/src/server/connection.rs
@@ -24,7 +24,9 @@ use tokio::time::timeout;
 use tracing::{debug, error, info, warn};
 
 use atm_claude_adapter::RawHookEvent;
+use atm_copilot_adapter::RawCopilotHookEvent;
 use atm_core::SessionId;
+use atm_devin_adapter::RawDevinHookEvent;
 use atm_pi_adapter::RawPiEvent;
 use atm_protocol::{ClientMessage, DaemonMessage, MessageType, ProtocolVersion};
 
@@ -282,6 +284,14 @@ impl ConnectionHandler {
                 self.handle_pi_event(data).await?;
             }
 
+            MessageType::DevinEvent { data } => {
+                self.handle_devin_event(data).await?;
+            }
+
+            MessageType::CopilotEvent { data } => {
+                self.handle_copilot_event(data).await?;
+            }
+
             MessageType::ListSessions => {
                 let sessions = self.registry.get_all_sessions().await;
                 self.send_message(DaemonMessage::session_list(sessions))
@@ -509,6 +519,111 @@ impl ConnectionHandler {
                 atm_core::Harness::Pi,
                 raw_event.pid,
                 raw_event.tmux_pane,
+            )
+            .await
+            .map_err(|e| ConnectionError::RegistryError(e.to_string()))?;
+
+        Ok(())
+    }
+
+    /// Handles a hook event from Devin CLI.
+    ///
+    /// Symmetric with [`Self::handle_hook_event`] — Devin CLI's hook
+    /// envelope is structurally close to Claude Code's, so the same
+    /// pattern applies with `atm-devin-adapter` in place of
+    /// `atm-claude-adapter`.
+    async fn handle_devin_event(&mut self, data: serde_json::Value) -> Result<(), ConnectionError> {
+        debug!(client_id = ?self.client_id, "Received Devin CLI hook event data");
+
+        let raw_event: RawDevinHookEvent =
+            serde_json::from_value(data).map_err(|e| ConnectionError::ParseError(e.to_string()))?;
+
+        debug!(
+            session_id = %raw_event.session_id(),
+            event_type = ?raw_event.event_type(),
+            pid = ?raw_event.pid,
+            tmux_pane = ?raw_event.tmux_pane,
+            "Processing Devin CLI hook event"
+        );
+
+        let lifecycle = match raw_event.to_lifecycle_event() {
+            Some(le) => le,
+            None => {
+                debug!(
+                    hook_event_name = %raw_event.hook_event_name,
+                    event_type = ?raw_event.event_type(),
+                    tool_name = ?raw_event.tool_name,
+                    "Devin hook event suppressed by adapter"
+                );
+                return Ok(());
+            }
+        };
+
+        let session_id = raw_event.session_id();
+        let pid = raw_event.pid;
+        let tmux_pane = raw_event.tmux_pane.clone();
+
+        self.registry
+            .apply_lifecycle_event(
+                session_id,
+                lifecycle,
+                atm_core::Harness::Devin,
+                pid,
+                tmux_pane,
+            )
+            .await
+            .map_err(|e| ConnectionError::RegistryError(e.to_string()))?;
+
+        Ok(())
+    }
+
+    /// Handles a hook event from GitHub Copilot CLI.
+    ///
+    /// Symmetric with [`Self::handle_hook_event`] — parses raw
+    /// Copilot-shaped JSON via `atm-copilot-adapter`, translates into
+    /// a vendor-neutral `LifecycleEvent`, and forwards to the
+    /// registry.
+    async fn handle_copilot_event(
+        &mut self,
+        data: serde_json::Value,
+    ) -> Result<(), ConnectionError> {
+        debug!(client_id = ?self.client_id, "Received Copilot CLI hook event data");
+
+        let raw_event: RawCopilotHookEvent =
+            serde_json::from_value(data).map_err(|e| ConnectionError::ParseError(e.to_string()))?;
+
+        debug!(
+            session_id = %raw_event.session_id(),
+            event_type = ?raw_event.event_type(),
+            pid = ?raw_event.pid,
+            tmux_pane = ?raw_event.tmux_pane,
+            "Processing Copilot CLI hook event"
+        );
+
+        let lifecycle = match raw_event.to_lifecycle_event() {
+            Some(le) => le,
+            None => {
+                debug!(
+                    hook_event_name = %raw_event.hook_event_name,
+                    event_type = ?raw_event.event_type(),
+                    tool_name = ?raw_event.tool_name,
+                    "Copilot hook event suppressed by adapter"
+                );
+                return Ok(());
+            }
+        };
+
+        let session_id = raw_event.session_id();
+        let pid = raw_event.pid;
+        let tmux_pane = raw_event.tmux_pane.clone();
+
+        self.registry
+            .apply_lifecycle_event(
+                session_id,
+                lifecycle,
+                atm_core::Harness::Copilot,
+                pid,
+                tmux_pane,
             )
             .await
             .map_err(|e| ConnectionError::RegistryError(e.to_string()))?;


### PR DESCRIPTION
## Summary

Adds first-class ATM support for **Devin CLI** and **GitHub Copilot
CLI**, matching the existing Claude Code / pi integration depth: live
dashboard tracking (tool activity, prompts, permission requests,
session lifecycle) — not just `atm spawn` support, which already
worked for arbitrary harnesses via the existing harness registry
(`crates/atm-core/src/harness_registry.rs`).

Both CLIs expose a hook system structurally similar to Claude Code's
(JSON-on-stdin command hooks, keyed by lifecycle event), so this
follows the exact same architecture as `atm-claude-adapter` /
`atm-pi-adapter`: a dedicated adapter crate owns each vendor's raw
event vocabulary and wire shape, and translates it into the existing
vendor-neutral `atm_core::LifecycleEvent` at the `atmd` connection
boundary. **No new `LifecycleEvent` variants were needed.**

## New crates

- **`atm-devin-adapter`** — Devin CLI's hook payload is snake_case and
  structurally close to Claude's (same `session_id`/`hook_event_name`
  correlation fields — see [Devin CLI hooks
  docs](https://docs.devin.ai/cli/extensibility/hooks/overview)), but
  its event set differs (`PermissionRequest` as its own event,
  `PostCompaction` instead of `PreCompact`, no
  Subagent/Setup/Notification events) and its tool names are
  lowercase/snake_case rather than Claude's PascalCase, so it gets its
  own event/wire/translate layer rather than reusing Claude's.
- **`atm-copilot-adapter`** — Copilot CLI's hook config and payloads
  are camelCase (`hooks.json`,
  `sessionId`/`toolName`/`toolArgs` — see [Copilot CLI hooks
  reference](https://docs.github.com/en/copilot/reference/hooks-reference)).
  `tool_args` is deserialized leniently since real CLI invocations
  have been observed sending it as a JSON-encoded *string* rather than
  an object
  ([github/copilot-cli#3349](https://github.com/github/copilot-cli/issues/3349)).
  Copilot's tool-name vocabulary isn't well-documented publicly, so —
  unlike the Devin adapter — no vendor-specific tool-name
  normalization is asserted; unknown names land in `Tool::Other` and
  still display correctly, just without the "well-known tool" label
  styling.

## Protocol / daemon wiring

- `atm-protocol`: adds `MessageType::DevinEvent` /
  `MessageType::CopilotEvent`, symmetric with the existing `HookEvent`
  / `PiEvent` variants.
- `atmd`: adds `handle_devin_event` / `handle_copilot_event` connection
  handlers, symmetric with `handle_hook_event` / `handle_pi_event`.
- `atm-core`: adds `Harness::Devin` / `Harness::Copilot`, and `devin` /
  `copilot` entries to the built-in harness registry
  (`discovery_enabled: true`, now that each has a real adapter backing
  its dashboard data).

## `atm setup` / `atm uninstall`

Detects Devin CLI (`~/.config/devin/`) and Copilot CLI (`~/.copilot/`,
or `$COPILOT_HOME`) the same way Claude Code / pi are detected
(presence of their config directory), installs a hook script for each
(`atm-devin-hook`, `atm-copilot-hook` — new files under
`crates/atm/scripts/`, mirroring `atm-hook`), and wires them into each
vendor's own hook configuration format:

- **Devin CLI**: `~/.config/devin/config.json`'s `hooks` key, in the
  same `{matcher, hooks: [{type, command}]}` shape Claude Code uses.
  (Devin CLI hardcodes this path on both macOS and Linux, unlike
  `dirs::config_dir()`, which resolves to `~/Library/Application
  Support` on macOS — see the doc comment on `devin_config_path`.)
- **Copilot CLI**: a new standalone `~/.copilot/hooks/atm.json` file
  (`{version: 1, hooks: {...}}`), since Copilot's hook entries are a
  flat array of `{type, command}` objects per event rather than
  Claude/Devin's nested `{matcher, hooks: [...]}` shape. I confirmed
  Copilot CLI does support a genuine user-level (non-repo-scoped)
  hooks directory (`~/.copilot/hooks/*.json`), so this doesn't need
  per-repo installation the way `.github/hooks/*.json` would.

  Copilot's individual event payloads don't carry a "which event is
  this" field (the event is implied by which `hooks.json` array
  invoked the command), so `atm-copilot-hook` is invoked once per
  event with the event name as an argument (e.g. `atm-copilot-hook
  preToolUse`) and injects it into the envelope as `hookEventName`
  before forwarding to atmd — see `atm_copilot_adapter::wire` module
  docs.

The `create_hook_entry` / `has_atm_hook` / `remove_atm_hooks` /
`install_hook_script` / `remove_hook_script` helpers in `setup.rs`
were generalized (marker string / path parameters) to be shared across
all three vendors instead of being Claude-specific.

Both new hook scripts walk the process tree via `ps -o comm=/ppid=`
rather than reading `/proc` directly (as the existing `atm-hook`
script does), so they work on macOS as well as Linux.

## Test plan

**Unit tests**: full coverage for both adapters' event/wire/translate
layers (event-name parsing, tool-shaped-event guards, tool-response
success/failure handling, camelCase/string-encoded `tool_args`
handling for Copilot), plus an updated
`test_only_adapter_backed_harnesses_are_discovery_enabled`.

**Manual end-to-end verification** (built and ran `atmd` + `atm`
locally): fed synthetic Devin CLI and Copilot CLI hook payloads through
the actual installed hook scripts / a raw socket client, and confirmed
via `atm list -f json` that:
- Sessions are correctly created and tagged `"harness": "devin"` /
  `"harness": "copilot"`.
- `PreToolUse`/`preToolUse` → `working`.
- `PermissionRequest`/`permissionRequest` → `attention_needed` with
  the gated tool name surfaced.
- `PostToolUse`/`postToolUseFailure` → tool call closed correctly
  (including the failure path for Copilot's separate
  `postToolUseFailure` event).
- `Stop` → `idle` (Devin).
- `SessionEnd`/`sessionEnd` → session removed.

Also verified `atm setup` / `atm uninstall` against a sandboxed `$HOME`
(not a real environment): confirmed correct
`~/.config/devin/config.json` and `~/.copilot/hooks/atm.json` content
matching each vendor's documented format, idempotent re-runs ("already
configured" on second run), and clean `atm uninstall` (scripts and
hook entries removed, unrelated config left untouched).

`cargo fmt` and `cargo clippy -- -D warnings` are clean for every
crate/file this PR touches (some pre-existing, unrelated
`cargo clippy -D warnings` lint failures exist elsewhere in the
codebase on current `main` — confirmed via `git stash` — and are out
of scope here).

## Known gap (documented, not guessed at)

Copilot CLI's exact tool-name vocabulary isn't publicly documented in
enough detail for me to be confident mapping it the way
`atm-devin-adapter` does for Devin's tool names, so I didn't guess.
Copilot tool names pass through as `Tool::Other(name)` — sessions and
tool activity still track correctly, just without "well-known tool"
label styling. Happy to add the mapping table in a follow-up once the
exact vocabulary is confirmed.

Generated with [Devin](https://devin.ai)
